### PR TITLE
Syscall filtering

### DIFF
--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -75,6 +75,13 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 		complete_all(&(vcpu->nitro.k_wait_cv));
 		// release all waiters on nitro_get_event
 		up(&(vcpu->nitro.n_wait_sem));
+		mutex_lock(&kvm->lock);
+		// clear syscall filter
+		int i;
+		for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
+			kvm->nitro.syscall_filter[i] = 0;
+		kvm->nitro.syscall_filter_size = 0;
+		mutex_unlock(&kvm->lock);
 	}
 
 

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -75,13 +75,7 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 		complete_all(&(vcpu->nitro.k_wait_cv));
 		// release all waiters on nitro_get_event
 		up(&(vcpu->nitro.n_wait_sem));
-		mutex_lock(&kvm->lock);
-		// clear syscall filter
-		int i;
-		for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
-			kvm->nitro.syscall_filter[i] = 0;
-		kvm->nitro.syscall_filter_size = 0;
-		mutex_unlock(&kvm->lock);
+		nitro_clear_syscall_filter(kvm);
 	}
 
 
@@ -119,8 +113,8 @@ void nitro_report_event(struct kvm_vcpu *vcpu, uint64_t syscall_nb){
 
 	// if no filter, report all events
 	// or if there is a filter
-	if (kvm->nitro.syscall_filter_size == 0
-			|| nitro_find_syscall(kvm, syscall_nb) == true)
+	if (hash_empty(kvm->nitro.syscall_filter_ht) == true
+			|| nitro_find_syscall(kvm, syscall_nb))
 	{
 		nitro_wait(vcpu);
 		vcpu->nitro.event.present = false;

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -5,7 +5,8 @@
 
 int nitro_set_syscall_trap(struct kvm*, bool enabled);
 void nitro_wait(struct kvm_vcpu*);
-void nitro_report_event(struct kvm_vcpu*);
+void nitro_report_event(struct kvm_vcpu*, uint64_t syscall_nb);
+void nitro_process_event(struct kvm_vcpu*);
 u64 nitro_get_efer(struct kvm_vcpu*);
 u64 nitro_get_old_sysenter_cs(void);
 

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6867,7 +6867,7 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 		
 
 		if(vcpu->nitro.event.present)
-			nitro_report_event(vcpu);
+			nitro_process_event(vcpu);
 
 		clear_bit(KVM_REQ_PENDING_TIMER, &vcpu->requests);
 		if (kvm_cpu_has_pending_timer(vcpu))

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -43,6 +43,7 @@ struct nitro_vcpus{
 //VM functions
 #define KVM_NITRO_ATTACH_VCPUS	_IOR(KVMIO, 0xE2, struct nitro_vcpus)
 #define KVM_NITRO_SET_SYSCALL_TRAP _IOW(KVMIO, 0xE3, bool)
+#define KVM_NITRO_ADD_SYSCALL_FILTER	_IOR(KVMIO, 0xEB, uint64_t)
 
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, struct event)

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -44,6 +44,7 @@ struct nitro_vcpus{
 #define KVM_NITRO_ATTACH_VCPUS	_IOR(KVMIO, 0xE2, struct nitro_vcpus)
 #define KVM_NITRO_SET_SYSCALL_TRAP _IOW(KVMIO, 0xE3, bool)
 #define KVM_NITRO_ADD_SYSCALL_FILTER	_IOR(KVMIO, 0xEB, uint64_t)
+#define KVM_NITRO_REMOVE_SYSCALL_FILTER	_IOR(KVMIO, 0xEC, uint64_t)
 
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, struct event)

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -9,6 +9,7 @@
 
 #define NITRO_TRAP_SYSCALL 1UL
 
+// 12 bits -> 1024 entries
 #define NITRO_SYSCALL_FILTER_HT_BITS 12
 
 struct syscall_stack_item
@@ -17,6 +18,9 @@ struct syscall_stack_item
 	struct list_head list;
 };
 
+// empty entry for the syscall hashtable
+// we only need the hashtable to get a O(1) access and
+// check if a syscall is present in the filter
 struct syscall_filter_ht_entry
 {
 	struct hlist_node node;

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -45,6 +45,7 @@ int nitro_ioctl_continue(struct kvm_vcpu*);
 
 int nitro_is_trap_set(struct kvm*, uint32_t);
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
+int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
 bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -1,6 +1,7 @@
 #ifndef NITRO_MAIN_H_
 #define NITRO_MAIN_H_
 
+#include <linux/hashtable.h>
 #include <linux/list.h>
 #include <linux/types.h>
 #include <linux/kvm_host.h>
@@ -8,7 +9,7 @@
 
 #define NITRO_TRAP_SYSCALL 1UL
 
-#define NITRO_SYSCALL_FILTER_MAX 1024
+#define NITRO_SYSCALL_FILTER_HT_BITS 12
 
 struct syscall_stack_item
 {
@@ -16,10 +17,14 @@ struct syscall_stack_item
 	struct list_head list;
 };
 
+struct syscall_filter_ht_entry
+{
+	struct hlist_node node;
+};
+
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
-  uint64_t syscall_filter[NITRO_SYSCALL_FILTER_MAX];
-  int syscall_filter_size;
+  DECLARE_HASHTABLE(syscall_filter_ht, NITRO_SYSCALL_FILTER_HT_BITS);
 };
 
 struct nitro_vcpu{
@@ -46,6 +51,7 @@ int nitro_ioctl_continue(struct kvm_vcpu*);
 int nitro_is_trap_set(struct kvm*, uint32_t);
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
 int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
-bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
+int nitro_clear_syscall_filter(struct kvm *kvm);
+struct syscall_filter_ht_entry* nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -18,7 +18,7 @@ struct syscall_stack_item
 
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
-  uint64_t syscall_filter[1024];
+  uint64_t syscall_filter[NITRO_SYSCALL_FILTER_MAX];
   int syscall_filter_size;
 };
 

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -7,16 +7,26 @@
 #include <linux/nitro.h>
 
 #define NITRO_TRAP_SYSCALL 1UL
-//#define NITRO_TRAP_XYZ  (1UL << 1)
+
+#define NITRO_SYSCALL_FILTER_MAX 1024
+
+struct syscall_stack_item
+{
+	uint64_t syscall_nb;
+	struct list_head list;
+};
 
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
+  uint64_t syscall_filter[1024];
+  int syscall_filter_size;
 };
 
 struct nitro_vcpu{
   struct completion k_wait_cv;
   struct semaphore n_wait_sem;
   struct event event;
+  struct syscall_stack_item stack;
 };
 
 struct kvm* nitro_get_vm_by_creator(pid_t);
@@ -34,6 +44,7 @@ int nitro_ioctl_get_event(struct kvm_vcpu*, struct event *ev);
 int nitro_ioctl_continue(struct kvm_vcpu*);
 
 int nitro_is_trap_set(struct kvm*, uint32_t);
-
+int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
+bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -3200,6 +3200,15 @@ out_free_irq_routing:
 		r = 0;
 		break;
 	}
+	case KVM_NITRO_ADD_SYSCALL_FILTER: {
+		uint64_t syscall_nb;
+		r = -EFAULT;
+		if (copy_from_user(&syscall_nb, argp, sizeof(uint64_t)))
+			goto out;
+
+		r = nitro_add_syscall_filter(kvm, syscall_nb);
+		break;
+	}
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -3209,6 +3209,15 @@ out_free_irq_routing:
 		r = nitro_add_syscall_filter(kvm, syscall_nb);
 		break;
 	}
+	case KVM_NITRO_REMOVE_SYSCALL_FILTER: {
+		uint64_t syscall_nb;
+		r = -EFAULT;
+		if (copy_from_user(&syscall_nb, argp, sizeof(uint64_t)))
+			goto out;
+
+		r = nitro_remove_syscall_filter(kvm, syscall_nb);
+		break;
+	}
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -194,13 +194,15 @@ int nitro_clear_syscall_filter(struct kvm *kvm)
 struct syscall_filter_ht_entry* nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb)
 {
 	uint64_t key = syscall_nb;
-	struct syscall_filter_ht_entry *found;
+	struct syscall_filter_ht_entry *found = NULL;
 
+	mutex_lock(&kvm->lock);
 	hash_for_each_possible(kvm->nitro.syscall_filter_ht, found, node, key)
 	{
-		return found;
+		break;
 	}
+	mutex_unlock(&kvm->lock);
 
-	return NULL;
+	return found;
 }
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -87,7 +87,7 @@ int nitro_iotcl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
     kvm_get_kvm(kvm);
     nvcpus->fds[r] = create_vcpu_fd(v);
     if(nvcpus->fds[r]<0){
-      for(i=r;r>=0;i--){
+      for(i=r;i>=0;i--){
 	nvcpus->ids[i] = 0;
 	nvcpus->fds[i] = 0;
 	kvm_put_kvm(kvm);

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -59,7 +59,16 @@ void nitro_create_vcpu_hook(struct kvm_vcpu *vcpu){
 }
 
 void nitro_destroy_vcpu_hook(struct kvm_vcpu *vcpu){
-  vcpu->nitro.event.present = false;
+	vcpu->nitro.event.present = false;
+	// destroy vcpu syscall stack
+	struct syscall_stack_item *tmp;
+	struct list_head *pos, *n;
+	list_for_each_safe(pos, n, &vcpu->nitro.stack.list)
+	{
+		tmp = list_entry(pos, struct syscall_stack_item, list);
+		list_del(pos);
+		kfree(tmp);
+	}
 }
 
 int nitro_iotcl_num_vms(void){

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -146,6 +146,7 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 		if (kvm->nitro.syscall_filter[i] == syscall_nb)
 			return 0;
 
+	mutex_lock(&kvm->lock);
 	// insert
 	kvm->nitro.syscall_filter_size++;
 	if (kvm->nitro.syscall_filter_size > NITRO_SYSCALL_FILTER_MAX)
@@ -156,6 +157,7 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 	}
 	int index = kvm->nitro.syscall_filter_size - 1;
 	kvm->nitro.syscall_filter[index] = syscall_nb;
+	mutex_unlock(&kvm->lock);
 	return 0;
 }
 
@@ -171,6 +173,7 @@ int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 		}
 	if (found == true)
 	{
+		mutex_lock(&kvm->lock);
 		int j;
 		for (j = i + 1; j < kvm->nitro.syscall_filter_size; j++)
 		{
@@ -178,7 +181,10 @@ int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 			kvm->nitro.syscall_filter[j-1] = kvm->nitro.syscall_filter[j];
 		}
 		kvm->nitro.syscall_filter_size--;
+		mutex_unlock(&kvm->lock);
 	}
+
+
 	return 0;
 }
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -159,6 +159,29 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 	return 0;
 }
 
+int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
+{
+	int i;
+	bool found = false;
+	for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
+		if (kvm->nitro.syscall_filter[i] == syscall_nb)
+		{
+			found = true;
+			break;
+		}
+	if (found == true)
+	{
+		int j;
+		for (j = i + 1; j < kvm->nitro.syscall_filter_size; j++)
+		{
+			// copy
+			kvm->nitro.syscall_filter[j-1] = kvm->nitro.syscall_filter[j];
+		}
+		kvm->nitro.syscall_filter_size--;
+	}
+	return 0;
+}
+
 bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb)
 {
 	int i;


### PR DESCRIPTION
This PR solves the performance issues of Nitro by moving the syscall filtering in the kernel.

The filtering has been implemented by a static array of `uint64_t` integers defined in the `nitro` struct. (`kvm.nitro`)

The nitro report event logic has been reworked to the following behavior:

Each event will go thought a `nitro_process_event` function, which is maintaing a stack
of syscall_number (the callstack).
If the direction is enter, then push the syscall number on the stack
else, pop the last element from the stack and get the syscall number

The stack allows us to know the syscall number when the event is in the `Exit` direction.

After that, the `nitro_report_event` will report the event if:

- no filter is defined (report everything)
- the syscall has been found in the filter
- otherwise, just continue the vm exection (return)

-> I would like to replace my static array by a set structure, but i couldn't  find a set interface in the kernel.