### PR TITLE
export kernel symbols used by KVM to compile it as a module

### DIFF
--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -1331,6 +1331,7 @@ int kill_pid_info(int sig, struct siginfo *info, struct pid *pid)
 		 */
 	}
 }
+EXPORT_SYMBOL(kill_pid_info);
 
 static int kill_proc_info(int sig, struct siginfo *info, pid_t pid)
 {

--- a/mm/gup.c
+++ b/mm/gup.c
@@ -417,6 +417,7 @@ struct page *follow_page_mask(struct vm_area_struct *vma,
 
 	return follow_p4d_mask(vma, address, pgd, flags, page_mask);
 }
+EXPORT_SYMBOL(follow_page_mask);
 
 static int get_gate_page(struct mm_struct *mm, unsigned long address,
 		unsigned int gup_flags, struct vm_area_struct **vma,

--- a/mm/huge_memory.c
+++ b/mm/huge_memory.c
@@ -2289,6 +2289,7 @@ void split_huge_pmd_address(struct vm_area_struct *vma, unsigned long address,
 
 	__split_huge_pmd(vma, pmd, address, freeze, page);
 }
+EXPORT_SYMBOL(split_huge_pmd_address);
 
 void vma_adjust_trans_huge(struct vm_area_struct *vma,
 			     unsigned long start,

--- a/mm/mempolicy.c
+++ b/mm/mempolicy.c
@@ -2002,6 +2002,7 @@ alloc_pages_vma(gfp_t gfp, int order, struct vm_area_struct *vma,
 out:
 	return page;
 }
+EXPORT_SYMBOL(alloc_pages_vma);
 
 /**
  * 	alloc_pages_current - Allocate pages.

--- a/mm/mmap.c
+++ b/mm/mmap.c
@@ -2626,6 +2626,7 @@ int split_vma(struct mm_struct *mm, struct vm_area_struct *vma,
 
 	return __split_vma(mm, vma, addr, new_below);
 }
+EXPORT_SYMBOL(split_vma);
 
 /* Munmap is split into 2 main parts -- this part which finds
  * what needs doing, and the areas themselves, which do the

--- a/mm/mmu_notifier.c
+++ b/mm/mmu_notifier.c
@@ -173,6 +173,7 @@ void __mmu_notifier_change_pte(struct mm_struct *mm, unsigned long address,
 	}
 	srcu_read_unlock(&srcu, id);
 }
+EXPORT_SYMBOL(__mmu_notifier_change_pte);
 
 void __mmu_notifier_invalidate_range_start(struct mm_struct *mm,
 				  unsigned long start, unsigned long end)

--- a/mm/pgtable-generic.c
+++ b/mm/pgtable-generic.c
@@ -87,6 +87,7 @@ pte_t ptep_clear_flush(struct vm_area_struct *vma, unsigned long address,
 		flush_tlb_page(vma, address);
 	return pte;
 }
+EXPORT_SYMBOL(ptep_clear_flush);
 #endif
 
 #ifdef CONFIG_TRANSPARENT_HUGEPAGE

--- a/mm/rmap.c
+++ b/mm/rmap.c
@@ -218,6 +218,7 @@ int __anon_vma_prepare(struct vm_area_struct *vma)
  out_enomem:
 	return -ENOMEM;
 }
+EXPORT_SYMBOL(__anon_vma_prepare);
 
 /*
  * This is a useful helper function for locking the anon_vma root as
@@ -371,6 +372,7 @@ int anon_vma_fork(struct vm_area_struct *vma, struct vm_area_struct *pvma)
 	unlink_anon_vmas(vma);
 	return -ENOMEM;
 }
+EXPORT_SYMBOL(anon_vma_fork);
 
 void unlink_anon_vmas(struct vm_area_struct *vma)
 {
@@ -418,6 +420,7 @@ void unlink_anon_vmas(struct vm_area_struct *vma)
 		anon_vma_chain_free(avc);
 	}
 }
+EXPORT_SYMBOL(unlink_anon_vmas);
 
 static void anon_vma_ctor(void *data)
 {
@@ -739,6 +742,7 @@ pmd_t *mm_find_pmd(struct mm_struct *mm, unsigned long address)
 out:
 	return pmd;
 }
+EXPORT_SYMBOL(mm_find_pmd);
 
 struct page_referenced_arg {
 	int mapcount;
@@ -1167,6 +1171,7 @@ void page_add_new_anon_rmap(struct page *page,
 	__mod_node_page_state(page_pgdat(page), NR_ANON_MAPPED, nr);
 	__page_set_anon_rmap(page, vma, address, 1);
 }
+EXPORT_SYMBOL(page_add_new_anon_rmap);
 
 /**
  * page_add_file_rmap - add pte mapping to a file page
@@ -1327,6 +1332,7 @@ void page_remove_rmap(struct page *page, bool compound)
 	 * faster for those pages still in swapcache.
 	 */
 }
+EXPORT_SYMBOL(page_remove_rmap);
 
 /*
  * @arg: enum ttu_flags will be passed to this argument

--- a/mm/swapfile.c
+++ b/mm/swapfile.c
@@ -1621,6 +1621,7 @@ int try_to_free_swap(struct page *page)
 	SetPageDirty(page);
 	return 1;
 }
+EXPORT_SYMBOL(try_to_free_swap);
 
 /*
  * Free the swap entry like above, but also try to


### PR DESCRIPTION
This PR exports a few kernel symbols that are required by KVM, allowing it to be compiled as an external module.

The error that we had before:
~~~
Kernel: arch/x86/boot/bzImage is ready  (#9)
  MODPOST 4843 modules
WARNING: modpost: missing MODULE_LICENSE() in drivers/auxdisplay/img-ascii-lcd.o
see include/linux/module.h for more information
WARNING: modpost: missing MODULE_LICENSE() in drivers/iio/accel/kxsd9-i2c.o
see include/linux/module.h for more information
WARNING: modpost: missing MODULE_LICENSE() in drivers/iio/adc/qcom-vadc-common.o
see include/linux/module.h for more information
WARNING: modpost: missing MODULE_LICENSE() in drivers/mtd/nand/denali_pci.o
see include/linux/module.h for more information
WARNING: modpost: missing MODULE_LICENSE() in sound/soc/codecs/snd-soc-pcm512x-spi.o
see include/linux/module.h for more information
ERROR: "follow_page_mask" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "page_remove_rmap" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "mm_find_pmd" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "__anon_vma_prepare" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "unlink_anon_vmas" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "__mmu_notifier_change_pte" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "ptep_clear_flush" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "alloc_pages_vma" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "anon_vma_fork" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "page_add_new_anon_rmap" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "try_to_free_swap" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "split_huge_pmd_address" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "kill_pid_info" [arch/x86/kvm/kvm.ko] undefined!
ERROR: "split_vma" [arch/x86/kvm/kvm.ko] undefined!
scripts/Makefile.modpost:92: recipe for target '__modpost' failed
make[1]: *** [__modpost] Error 1
Makefile:1208: recipe for target 'modules' failed
make: *** [modules] Error 2
~~~

Some of these functions have multiple implementation, for example `ptep_clear_flush` ([Elixir](http://elixir.free-electrons.com/linux/v4.6/ident/ptep_clear_flush), so just exported the one that was making more sense (here in http://elixir.free-electrons.com/linux/v4.6/ident/ptep_clear_flush).

Comments and feedbacks are welcome, i'm not an expert in Linux kernel development !
cc @adlazar, @mdontu