### PR TITLE
Add "continue step over" ioctl

### DIFF
--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -800,7 +800,6 @@ static int segmented_read_std(struct x86_emulate_ctxt *ctxt,
  */
 static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 {
-	char *type;
 	int rc;
 	unsigned size, max_size;
 	unsigned long linear;
@@ -821,17 +820,6 @@ static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 	rc = __linearize(ctxt, addr, &max_size, 0, false, true, ctxt->mode,
 			 &linear);
 	if (unlikely(rc != X86EMUL_CONTINUE)) {
-		switch (rc) {
-		case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
-		case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
-		case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
-		case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
-		case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
-		case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
-		case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
-		default: type = "unknown"; break;
-		}
-		printk("__do_insn_fetch_bytes: __linearize failed with %s", type);
 		return rc;
 	}
 
@@ -850,17 +838,6 @@ static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 	rc = ctxt->ops->fetch(ctxt, linear, ctxt->fetch.end,
 			      size, &ctxt->exception);
 	if (unlikely(rc != X86EMUL_CONTINUE)) {
-		switch (rc) {
-		case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
-		case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
-		case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
-		case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
-		case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
-		case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
-		case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
-		default: type = "unknown"; break;
-		}
-		printk("__do_insn_fetch_bytes: ctxt->ops->fetch failed with %s", type);
 		return rc;
 	}
 	ctxt->fetch.end += size;
@@ -4920,18 +4897,6 @@ int x86_decode_insn(struct x86_emulate_ctxt *ctxt, void *insn, int insn_len)
 	else {
 		rc = __do_insn_fetch_bytes(ctxt, 1);
 		if (rc != X86EMUL_CONTINUE) {
-			char *type;
-			switch (rc) {
-			case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
-			case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
-			case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
-			case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
-			case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
-			case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
-			case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
-			default: type = "unknown"; break;
-			}
-			printk("x86_decode_insn: __do_insn_fetch_bytes failed with %s", type);
 			return rc;
 		}
 	}

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2628,16 +2628,6 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		printk("filling nitro.event from em_syscall");
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSCALL;
-		vcpu->nitro.event.direction = ENTER;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
-
-
 	/* syscall is not available in real mode */
 	if (ctxt->mode == X86EMUL_MODE_REAL ||
 	    ctxt->mode == X86EMUL_MODE_VM86)
@@ -2754,15 +2744,6 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 	ctxt->eflags = (reg_read(ctxt, VCPU_REGS_R11) & 0x3c7fd7) | 0x2;
 
 	ctxt->_eip = reg_read(ctxt, VCPU_REGS_RCX);
-	
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		printk("filling nitro.event from em_sysret");
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSCALL;
-		vcpu->nitro.event.direction = EXIT;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
 
 	return X86EMUL_CONTINUE;
 }

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2712,6 +2712,7 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	setup_syscalls_segments(ctxt, &cs, &ss);
 
+	// Is this a problem now that we do not handle the event delivery here
 	if (!(efer & EFER_SCE) && !nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
 		return emulate_ud(ctxt);
 

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2629,6 +2629,7 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
 	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		printk("filling nitro.event from em_syscall");
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSCALL;
 		vcpu->nitro.event.direction = ENTER;
@@ -2755,6 +2756,7 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 	ctxt->_eip = reg_read(ctxt, VCPU_REGS_RCX);
 	
 	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		printk("filling nitro.event from em_sysret");
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSCALL;
 		vcpu->nitro.event.direction = EXIT;
@@ -2775,6 +2777,7 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
 	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		printk("filling nitro.event from em_sysenter");
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSENTER;
 		vcpu->nitro.event.direction = ENTER;
@@ -2890,6 +2893,7 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 	*reg_write(ctxt, VCPU_REGS_RSP) = rcx;
 
 	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		printk("filling nitro.event from em_sysexit");
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSENTER;
 		vcpu->nitro.event.direction = EXIT;

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2628,14 +2628,6 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSCALL;
-		vcpu->nitro.event.direction = ENTER;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
-
 
 	/* syscall is not available in real mode */
 	if (ctxt->mode == X86EMUL_MODE_REAL ||
@@ -2648,7 +2640,7 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	setup_syscalls_segments(ctxt, &cs, &ss);
 
-	if (!(efer & EFER_SCE) && !nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
+	if (!(efer & EFER_SCE))
 		return emulate_ud(ctxt);
 	
 	ops->get_msr(ctxt, MSR_STAR, &msr_data);
@@ -2754,13 +2746,13 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 
 	ctxt->_eip = reg_read(ctxt, VCPU_REGS_RCX);
 	
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSCALL;
-		vcpu->nitro.event.direction = EXIT;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
+	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
+	/* 	vcpu->nitro.event.present = true; */
+	/* 	vcpu->nitro.event.type = SYSCALL; */
+	/* 	vcpu->nitro.event.direction = EXIT; */
+	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
+	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
+	/* } */
 
 	return X86EMUL_CONTINUE;
 }
@@ -2774,13 +2766,13 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSENTER;
-		vcpu->nitro.event.direction = ENTER;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
+	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
+	/* 	vcpu->nitro.event.present = true; */
+	/* 	vcpu->nitro.event.type = SYSENTER; */
+	/* 	vcpu->nitro.event.direction = ENTER; */
+	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
+	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
+	/* } */
 
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	/* inject #GP if in real mode */
@@ -2889,13 +2881,13 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 	ctxt->_eip = rdx;
 	*reg_write(ctxt, VCPU_REGS_RSP) = rcx;
 
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSENTER;
-		vcpu->nitro.event.direction = EXIT;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
+	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
+	/* 	vcpu->nitro.event.present = true; */
+	/* 	vcpu->nitro.event.type = SYSENTER; */
+	/* 	vcpu->nitro.event.direction = EXIT; */
+	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
+	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
+	/* } */
 
 	return X86EMUL_CONTINUE;
 }

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2718,7 +2718,6 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 	if (!(efer & EFER_SCE) && !nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
 		return emulate_ud(ctxt);
 
-
 	ops->get_msr(ctxt, MSR_STAR, &msr_data);
 	msr_data >>= 48;
 	
@@ -2759,15 +2758,6 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 	u16 cs_sel, ss_sel;
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
-
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		printk("filling nitro.event from em_sysenter");
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSENTER;
-		vcpu->nitro.event.direction = ENTER;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
 
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	/* inject #GP if in real mode */
@@ -2875,15 +2865,6 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 
 	ctxt->_eip = rdx;
 	*reg_write(ctxt, VCPU_REGS_RSP) = rcx;
-
-	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-		printk("filling nitro.event from em_sysexit");
-		vcpu->nitro.event.present = true;
-		vcpu->nitro.event.type = SYSENTER;
-		vcpu->nitro.event.direction = EXIT;
-		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-	}
 
 	return X86EMUL_CONTINUE;
 }

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2628,6 +2628,14 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		vcpu->nitro.event.present = true;
+		vcpu->nitro.event.type = SYSCALL;
+		vcpu->nitro.event.direction = ENTER;
+		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
+		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
+	}
+
 
 	/* syscall is not available in real mode */
 	if (ctxt->mode == X86EMUL_MODE_REAL ||
@@ -2640,7 +2648,7 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	setup_syscalls_segments(ctxt, &cs, &ss);
 
-	if (!(efer & EFER_SCE))
+	if (!(efer & EFER_SCE) && !nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
 		return emulate_ud(ctxt);
 	
 	ops->get_msr(ctxt, MSR_STAR, &msr_data);
@@ -2746,13 +2754,13 @@ static int em_sysret(struct x86_emulate_ctxt *ctxt)
 
 	ctxt->_eip = reg_read(ctxt, VCPU_REGS_RCX);
 	
-	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
-	/* 	vcpu->nitro.event.present = true; */
-	/* 	vcpu->nitro.event.type = SYSCALL; */
-	/* 	vcpu->nitro.event.direction = EXIT; */
-	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
-	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
-	/* } */
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		vcpu->nitro.event.present = true;
+		vcpu->nitro.event.type = SYSCALL;
+		vcpu->nitro.event.direction = EXIT;
+		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
+		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
+	}
 
 	return X86EMUL_CONTINUE;
 }
@@ -2766,13 +2774,13 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 	u64 efer = 0;
 	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
-	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
-	/* 	vcpu->nitro.event.present = true; */
-	/* 	vcpu->nitro.event.type = SYSENTER; */
-	/* 	vcpu->nitro.event.direction = ENTER; */
-	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
-	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
-	/* } */
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		vcpu->nitro.event.present = true;
+		vcpu->nitro.event.type = SYSENTER;
+		vcpu->nitro.event.direction = ENTER;
+		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
+		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
+	}
 
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	/* inject #GP if in real mode */
@@ -2881,13 +2889,13 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 	ctxt->_eip = rdx;
 	*reg_write(ctxt, VCPU_REGS_RSP) = rcx;
 
-	/* if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){ */
-	/* 	vcpu->nitro.event.present = true; */
-	/* 	vcpu->nitro.event.type = SYSENTER; */
-	/* 	vcpu->nitro.event.direction = EXIT; */
-	/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
-	/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
-	/* } */
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+		vcpu->nitro.event.present = true;
+		vcpu->nitro.event.type = SYSENTER;
+		vcpu->nitro.event.direction = EXIT;
+		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
+		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
+	}
 
 	return X86EMUL_CONTINUE;
 }

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -800,6 +800,7 @@ static int segmented_read_std(struct x86_emulate_ctxt *ctxt,
  */
 static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 {
+	char *type;
 	int rc;
 	unsigned size, max_size;
 	unsigned long linear;
@@ -819,8 +820,20 @@ static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 	 */
 	rc = __linearize(ctxt, addr, &max_size, 0, false, true, ctxt->mode,
 			 &linear);
-	if (unlikely(rc != X86EMUL_CONTINUE))
+	if (unlikely(rc != X86EMUL_CONTINUE)) {
+		switch (rc) {
+		case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
+		case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
+		case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
+		case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
+		case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
+		case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
+		case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
+		default: type = "unknown"; break;
+		}
+		printk("__do_insn_fetch_bytes: __linearize failed with %s", type);
 		return rc;
+	}
 
 	size = min_t(unsigned, 15UL ^ cur_size, max_size);
 	size = min_t(unsigned, size, PAGE_SIZE - offset_in_page(linear));
@@ -836,8 +849,20 @@ static int __do_insn_fetch_bytes(struct x86_emulate_ctxt *ctxt, int op_size)
 
 	rc = ctxt->ops->fetch(ctxt, linear, ctxt->fetch.end,
 			      size, &ctxt->exception);
-	if (unlikely(rc != X86EMUL_CONTINUE))
+	if (unlikely(rc != X86EMUL_CONTINUE)) {
+		switch (rc) {
+		case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
+		case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
+		case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
+		case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
+		case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
+		case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
+		case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
+		default: type = "unknown"; break;
+		}
+		printk("__do_insn_fetch_bytes: ctxt->ops->fetch failed with %s", type);
 		return rc;
+	}
 	ctxt->fetch.end += size;
 	return X86EMUL_CONTINUE;
 }
@@ -4894,8 +4919,21 @@ int x86_decode_insn(struct x86_emulate_ctxt *ctxt, void *insn, int insn_len)
 		memcpy(ctxt->fetch.data, insn, insn_len);
 	else {
 		rc = __do_insn_fetch_bytes(ctxt, 1);
-		if (rc != X86EMUL_CONTINUE)
+		if (rc != X86EMUL_CONTINUE) {
+			char *type;
+			switch (rc) {
+			case X86EMUL_CONTINUE: type = "X86EMUL_CONTINUE"; break;
+			case X86EMUL_UNHANDLEABLE: type = "X86EMUL_UNHANDLEABLE"; break;
+			case X86EMUL_PROPAGATE_FAULT: type = "X86EMUL_PROPAGATE_FAULT"; break;
+			case X86EMUL_RETRY_INSTR: type = "X86EMUL_RETRY_INSTR"; break;
+			case X86EMUL_CMPXCHG_FAILED: type = "X86EMUL_CMPXCHG_FAILED"; break;
+			case X86EMUL_IO_NEEDED: type = "X86EMUL_IO_NEEDED"; break;
+			case X86EMUL_INTERCEPTED: type = "X86EMUL_INTERCEPTED"; break;
+			default: type = "unknown"; break;
+			}
+			printk("x86_decode_insn: __do_insn_fetch_bytes failed with %s", type);
 			return rc;
+		}
 	}
 
 	switch (mode) {

--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -2772,17 +2772,15 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 	u64 msr_data;
 	u16 cs_sel, ss_sel;
 	u64 efer = 0;
-    struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
+	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
-	// printk(KERN_INFO "em_sysenter\n");
-
-    if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSENTER;
 		vcpu->nitro.event.direction = ENTER;
 		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
 		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-    }
+	}
 
 	ops->get_msr(ctxt, MSR_EFER, &efer);
 	/* inject #GP if in real mode */
@@ -2803,10 +2801,10 @@ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
 
 	setup_syscalls_segments(ctxt, &cs, &ss);
 
-    if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
-        msr_data = nitro_get_old_sysenter_cs();
-    else
-        ops->get_msr(ctxt, MSR_IA32_SYSENTER_CS, &msr_data);
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
+		msr_data = nitro_get_old_sysenter_cs();
+	else
+		ops->get_msr(ctxt, MSR_IA32_SYSENTER_CS, &msr_data);
 	if ((msr_data & 0xfffc) == 0x0)
 		return emulate_gp(ctxt, 0);
 
@@ -2838,9 +2836,7 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 	u64 msr_data, rcx, rdx;
 	int usermode;
 	u16 cs_sel = 0, ss_sel = 0;
-    struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
-
-	// printk(KERN_INFO "em_sysexit\n");
+	struct kvm_vcpu *vcpu = container_of(ctxt, struct kvm_vcpu, arch.emulate_ctxt);
 
 	/* inject #GP if in real mode or Virtual 8086 mode */
 	if (ctxt->mode == X86EMUL_MODE_REAL ||
@@ -2859,10 +2855,10 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 
 	cs.dpl = 3;
 	ss.dpl = 3;
-    if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
-        msr_data = nitro_get_old_sysenter_cs();
-    else
-        ops->get_msr(ctxt, MSR_IA32_SYSENTER_CS, &msr_data);
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL))
+		msr_data = nitro_get_old_sysenter_cs();
+	else
+		ops->get_msr(ctxt, MSR_IA32_SYSENTER_CS, &msr_data);
 	switch (usermode) {
 	case X86EMUL_MODE_PROT32:
 		cs_sel = (u16)(msr_data + 16);
@@ -2893,13 +2889,13 @@ static int em_sysexit(struct x86_emulate_ctxt *ctxt)
 	ctxt->_eip = rdx;
 	*reg_write(ctxt, VCPU_REGS_RSP) = rcx;
 
-    if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+	if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 		vcpu->nitro.event.present = true;
 		vcpu->nitro.event.type = SYSENTER;
 		vcpu->nitro.event.direction = EXIT;
 		kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
 		kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-    }
+	}
 
 	return X86EMUL_CONTINUE;
 }

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -95,9 +95,9 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 }
 
 static void nitro_do_continue(struct kvm_vcpu *vcpu) {
+  char *type;
   long er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
   if (er != EMULATE_DONE) {
-    char *type;
     switch (er) {
     case EMULATE_DONE: type = "EMULATE_DONE"; break;
     case EMULATE_USER_EXIT: type = "EMULATE_USER_EXIT"; break;

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -16,18 +16,15 @@ static void nitro_set_trap_sysenter_cs(struct kvm_vcpu* vcpu, bool enabled)
   printk(KERN_INFO "nitro: setting trap on sysenter CS to %d\n", enabled);
 	msr_info.index = MSR_IA32_SYSENTER_CS;
 	msr_info.host_initiated = true;
-	if (enabled)
-    {
-      kvm_x86_ops->get_msr(vcpu, &msr_info);
-      old_sysenter_cs = msr_info.data;
-      printk(KERN_INFO "nitro: old sysenter cs = 0x%llx\n", old_sysenter_cs);
-      msr_info.data = 0;
-    }
-  else
-    {
-      printk(KERN_INFO "nitro: restoring syscenter cs to 0x%llx\n", old_sysenter_cs);
-      msr_info.data = old_sysenter_cs;
-    }
+	if (enabled) {
+    kvm_x86_ops->get_msr(vcpu, &msr_info);
+    old_sysenter_cs = msr_info.data;
+    printk(KERN_INFO "nitro: old sysenter cs = 0x%llx\n", old_sysenter_cs);
+    msr_info.data = 0;
+  } else {
+    printk(KERN_INFO "nitro: restoring syscenter cs to 0x%llx\n", old_sysenter_cs);
+    msr_info.data = old_sysenter_cs;
+  }
 	kvm_x86_ops->set_msr(vcpu, &msr_info);
 }
 
@@ -158,17 +155,16 @@ EXPORT_SYMBOL_GPL(nitro_should_propagate);
 // Maybe some locking should be in place...
 bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result)
 {
-	uint64_t syscall_nb = 0;
+  uint64_t syscall_nb = 0;
   bool success = true;
   struct syscall_stack_item *item;
-	if (vcpu->nitro.event.direction == ENTER) {
+  if (vcpu->nitro.event.direction == ENTER) {
     printk(KERN_DEBUG "nitro_get_syscall_num: got ENTER event");
-		syscall_nb = vcpu->nitro.event.regs.rax;
-		item = kmalloc(sizeof(struct syscall_stack_item), GFP_KERNEL);
-		item->syscall_nb = syscall_nb;
-		list_add_tail(&item->list, &vcpu->nitro.stack.list);
-	}
-	else {
+    syscall_nb = vcpu->nitro.event.regs.rax;
+    item = kmalloc(sizeof(struct syscall_stack_item), GFP_KERNEL);
+    item->syscall_nb = syscall_nb;
+    list_add_tail(&item->list, &vcpu->nitro.stack.list);
+  } else {
     printk(KERN_DEBUG "nitro_get_syscall_num: got EXIT event");
 		if (!list_empty(&vcpu->nitro.stack.list)) {
 			struct syscall_stack_item *item;
@@ -188,6 +184,7 @@ bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result)
 
 
 u64 nitro_get_efer(struct kvm_vcpu *vcpu){
-  return nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL) ? (vcpu->arch.efer | EFER_SCE) : vcpu->arch.efer;
+  return nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)
+    ? (vcpu->arch.efer | EFER_SCE) : vcpu->arch.efer;
 }
 

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -124,7 +124,7 @@ void nitro_report_event(struct kvm_vcpu *vcpu, uint64_t syscall_nb){
 
 void nitro_process_event(struct kvm_vcpu *vcpu)
 {
-  printk("nitro_process_event called");
+  printk(KERN_DEBUG "nitro_process_event called");
 	uint64_t syscall_nb = 0;
 	if (vcpu->nitro.event.direction == ENTER)
 	{

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -96,6 +96,7 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 
 void nitro_wait(struct kvm_vcpu *vcpu){
   long rv;
+  printk("nitro_wait called");
   
   up(&(vcpu->nitro.n_wait_sem));
   rv = wait_for_completion_interruptible_timeout(&(vcpu->nitro.k_wait_cv),msecs_to_jiffies(30000));
@@ -123,6 +124,7 @@ void nitro_report_event(struct kvm_vcpu *vcpu, uint64_t syscall_nb){
 
 void nitro_process_event(struct kvm_vcpu *vcpu)
 {
+  printk("nitro_process_event called");
 	uint64_t syscall_nb = 0;
 	if (vcpu->nitro.event.direction == ENTER)
 	{

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -107,7 +107,7 @@ void nitro_wait(struct kvm_vcpu *vcpu){
   switch (vcpu->nitro.cont) {
   case NITRO_CONTINUATION_CONTINUE:
     printk("nitro_wait: received continue event");
-    if (!(is_syscall(vcpu) || !is_sysret(vcpu))) {
+    if (!(is_syscall(vcpu) || is_sysret(vcpu))) {
       printk("ERROR: nitro_wait processing cont event on instruction other than syscall or sysret");
     }
 

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -75,6 +75,13 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 		complete_all(&(vcpu->nitro.k_wait_cv));
 		// release all waiters on nitro_get_event
 		up(&(vcpu->nitro.n_wait_sem));
+		mutex_lock(&kvm->lock);
+		// clear syscall filter
+		int i;
+		for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
+			kvm->nitro.syscall_filter[i] = 0;
+		kvm->nitro.syscall_filter_size = 0;
+		mutex_unlock(&kvm->lock);
 	}
 
 

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -75,13 +75,7 @@ int nitro_set_syscall_trap(struct kvm *kvm, bool enabled){
 		complete_all(&(vcpu->nitro.k_wait_cv));
 		// release all waiters on nitro_get_event
 		up(&(vcpu->nitro.n_wait_sem));
-		mutex_lock(&kvm->lock);
-		// clear syscall filter
-		int i;
-		for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
-			kvm->nitro.syscall_filter[i] = 0;
-		kvm->nitro.syscall_filter_size = 0;
-		mutex_unlock(&kvm->lock);
+		nitro_clear_syscall_filter(kvm);
 	}
 
 
@@ -119,8 +113,8 @@ void nitro_report_event(struct kvm_vcpu *vcpu, uint64_t syscall_nb){
 
 	// if no filter, report all events
 	// or if there is a filter
-	if (kvm->nitro.syscall_filter_size == 0
-			|| nitro_find_syscall(kvm, syscall_nb) == true)
+	if (hash_empty(kvm->nitro.syscall_filter_ht) == true
+			|| nitro_find_syscall(kvm, syscall_nb))
 	{
 		nitro_wait(vcpu);
 		vcpu->nitro.event.present = false;

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -144,10 +144,10 @@ void nitro_wait(struct kvm_vcpu *vcpu) {
 }
 EXPORT_SYMBOL_GPL(nitro_do_continue_step_over);
 
-bool nitro_should_propagate(struct kvm_vcpu *vcpu) {
+bool nitro_should_propagate(struct kvm_vcpu *vcpu, enum syscall_direction dir) {
   uint64_t syscall_num;
   if (!hash_empty(vcpu->kvm->nitro.syscall_filter_ht)) {
-    return nitro_get_syscall_num(vcpu, &syscall_num) && nitro_find_syscall(vcpu->kvm, syscall_num);
+    return nitro_get_syscall_num(vcpu, dir, &syscall_num) && nitro_find_syscall(vcpu->kvm, syscall_num);
     
   }
   return true;
@@ -155,11 +155,11 @@ bool nitro_should_propagate(struct kvm_vcpu *vcpu) {
 EXPORT_SYMBOL_GPL(nitro_should_propagate);
 
 // Maybe some locking should be in place...
-bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result) {
+bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, enum syscall_direction dir, uint64_t *result) {
   uint64_t syscall_nb = 0;
   bool success = true;
   struct syscall_stack_item *item;
-  if (vcpu->nitro.event.direction == ENTER) {
+  if (dir == ENTER) {
     printk(KERN_DEBUG "nitro_get_syscall_num: got ENTER event");
     syscall_nb = kvm_register_read(vcpu, VCPU_REGS_RAX);
     item = kmalloc(sizeof(struct syscall_stack_item), GFP_KERNEL);

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -148,6 +148,7 @@ bool nitro_should_propagate(struct kvm_vcpu *vcpu) {
   uint64_t syscall_num;
   if (!hash_empty(vcpu->kvm->nitro.syscall_filter_ht)) {
     return nitro_get_syscall_num(vcpu, &syscall_num) && nitro_find_syscall(vcpu->kvm, syscall_num);
+    
   }
   return true;
 }
@@ -160,7 +161,7 @@ bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result) {
   struct syscall_stack_item *item;
   if (vcpu->nitro.event.direction == ENTER) {
     printk(KERN_DEBUG "nitro_get_syscall_num: got ENTER event");
-    syscall_nb = vcpu->nitro.event.regs.rax;
+    syscall_nb = kvm_register_read(vcpu, VCPU_REGS_RAX);
     item = kmalloc(sizeof(struct syscall_stack_item), GFP_KERNEL);
     item->syscall_nb = syscall_nb;
     list_add_tail(&item->list, &vcpu->nitro.stack.list);

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -122,7 +122,7 @@ void nitro_wait(struct kvm_vcpu *vcpu) {
   printk(KERN_DEBUG "nitro_wait: past up");
 
   // Note we do not have a timeout here. Let's be careful.
-  wait_for_completion(&(vcpu->nitro.k_wait_cv));
+  wait_for_completion_killable(&(vcpu->nitro.k_wait_cv));
   printk(KERN_DEBUG "nitro_wait: past wait_for_completion");
 
   if (vcpu->nitro.event.direction == ENTER) {

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -9,6 +9,10 @@ void nitro_report_event(struct kvm_vcpu*, uint64_t syscall_nb);
 void nitro_process_event(struct kvm_vcpu*);
 u64 nitro_get_efer(struct kvm_vcpu*);
 u64 nitro_get_old_sysenter_cs(void);
+bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result);
+bool nitro_should_propagate(struct kvm_vcpu *vcpu);
+void nitro_do_continue(struct kvm_vcpu *vcpu);
+void nitro_do_continue_step_over(struct kvm_vcpu *vcpu);
 
 
 #endif //NITRO_X86_H_

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -5,7 +5,8 @@
 
 int nitro_set_syscall_trap(struct kvm*, bool enabled);
 void nitro_wait(struct kvm_vcpu*);
-void nitro_report_event(struct kvm_vcpu*);
+void nitro_report_event(struct kvm_vcpu*, uint64_t syscall_nb);
+void nitro_process_event(struct kvm_vcpu*);
 u64 nitro_get_efer(struct kvm_vcpu*);
 u64 nitro_get_old_sysenter_cs(void);
 

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -9,8 +9,8 @@ void nitro_report_event(struct kvm_vcpu*, uint64_t syscall_nb);
 void nitro_process_event(struct kvm_vcpu*);
 u64 nitro_get_efer(struct kvm_vcpu*);
 u64 nitro_get_old_sysenter_cs(void);
-bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, uint64_t *result);
-bool nitro_should_propagate(struct kvm_vcpu *vcpu);
+bool nitro_get_syscall_num(struct kvm_vcpu *vcpu, enum syscall_direction dir, uint64_t *result);
+bool nitro_should_propagate(struct kvm_vcpu *vcpu, enum syscall_direction dir);
 void nitro_do_continue(struct kvm_vcpu *vcpu);
 void nitro_do_continue_step_over(struct kvm_vcpu *vcpu);
 

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5505,21 +5505,9 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			kvm_queue_exception(vcpu, UD_VECTOR);
 			return 1;
 		}
-		/* if (nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)) { */
-   	/* 	printk(KERN_DEBUG "handle_exception called with nitro trap present and syscall enter"); */
-		/* 	vcpu->nitro.event.present = true; */
-		/* 	vcpu->nitro.event.type = SYSCALL; */
-		/* 	vcpu->nitro.event.direction = ENTER; */
-		/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
-		/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
-
-		/* 	// This is only used so we do not have to change user space API and Qemu */
-		/* 	// seems to do the right thing here. */
-		/* 	vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN; */
-		/* 	return 0; */
-		/* } */
-		
-		kvm_queue_exception(vcpu, UD_VECTOR);
+		er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
+		if (er != EMULATE_DONE)
+			kvm_queue_exception(vcpu, UD_VECTOR);
 		return 1;
 	}
 
@@ -5532,19 +5520,9 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 	{
 		if (is_sysenter_sysexit(vcpu))
 		{
-			/* if (nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)) { */
-			/* 	printk(KERN_DEBUG "handle_exception called with nitro trap present and sysenter"); */
-			/* 	vcpu->nitro.event.present = true; */
-			/* 	vcpu->nitro.event.type = SYSCALL; */
-			/* 	vcpu->nitro.event.direction = ENTER; */
-			/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
-			/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
-
-			/* 	vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN; */
-			/* 	return 0; */
-			/* } */
-
-			kvm_queue_exception(vcpu, UD_VECTOR);
+			er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
+			if (er != EMULATE_DONE)
+				kvm_queue_exception(vcpu, UD_VECTOR);
 			return 1;
 		}else
 		{

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5505,9 +5505,21 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			kvm_queue_exception(vcpu, UD_VECTOR);
 			return 1;
 		}
-		er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
-		if (er != EMULATE_DONE)
-			kvm_queue_exception(vcpu, UD_VECTOR);
+		/* if (nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)) { */
+   	/* 	printk(KERN_DEBUG "handle_exception called with nitro trap present and syscall enter"); */
+		/* 	vcpu->nitro.event.present = true; */
+		/* 	vcpu->nitro.event.type = SYSCALL; */
+		/* 	vcpu->nitro.event.direction = ENTER; */
+		/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
+		/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
+
+		/* 	// This is only used so we do not have to change user space API and Qemu */
+		/* 	// seems to do the right thing here. */
+		/* 	vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN; */
+		/* 	return 0; */
+		/* } */
+		
+		kvm_queue_exception(vcpu, UD_VECTOR);
 		return 1;
 	}
 
@@ -5520,9 +5532,19 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 	{
 		if (is_sysenter_sysexit(vcpu))
 		{
-			er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
-			if (er != EMULATE_DONE)
-				kvm_queue_exception(vcpu, UD_VECTOR);
+			/* if (nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)) { */
+			/* 	printk(KERN_DEBUG "handle_exception called with nitro trap present and sysenter"); */
+			/* 	vcpu->nitro.event.present = true; */
+			/* 	vcpu->nitro.event.type = SYSCALL; */
+			/* 	vcpu->nitro.event.direction = ENTER; */
+			/* 	kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs)); */
+			/* 	kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs)); */
+
+			/* 	vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN; */
+			/* 	return 0; */
+			/* } */
+
+			kvm_queue_exception(vcpu, UD_VECTOR);
 			return 1;
 		}else
 		{

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5507,41 +5507,26 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			return 1;
 		}
 		if (is_syscall(vcpu)) {
-			printk("handle_exception on syscall");
+			printk(KERN_DEBUG "handle_exception: syscall");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 				if (nitro_should_propagate(vcpu)) {
-					printk(KERN_DEBUG "handle_exception: filling nitro.event with syscall");
-					vcpu->nitro.event.present = true;
-					vcpu->nitro.event.type = SYSCALL;
-					vcpu->nitro.event.direction = ENTER;
-					kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-					kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-					// Let's try what Qemu does with this. If we are not interested in this
-					// event maybe we shouldn't event exit_here but emulate the event
-					// directly
-					vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN;
+					printk("syscall propagated");
+					nitro_fill_event(vcpu, SYSCALL, ENTER);
 					return 0;
 				} else {
-					printk("handle_exception: got syscall that was not interesting.");
 					nitro_do_continue(vcpu);
 					return 1;
 				}
 			}
 		} else if (is_sysret(vcpu)) {
-			printk("handle_exception on sysret");
+			printk(KERN_DEBUG "handle_exception: sysret");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+				nitro_do_continue(vcpu);
 				if (nitro_should_propagate(vcpu)) {
-					printk(KERN_DEBUG "handle_exception: filling nitro.event from with sysret");
-					vcpu->nitro.event.present = true;
-					vcpu->nitro.event.type = SYSCALL;
-					vcpu->nitro.event.direction = EXIT;
-					kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-					kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-					vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN;
+					printk("sysret propagated");
+					nitro_fill_event(vcpu, SYSCALL, EXIT);
 					return 0;
 				} else {
-					printk("handle_exception: got sysret that was not interesting.");
-					nitro_do_continue(vcpu);
 					return 1;
 				}
 			}
@@ -5559,17 +5544,11 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 
 	if (is_general_protection(intr_info) &&
 			vcpu->kvm->nitro.traps) {
-		// sysenter/sysexit handling is currently broken
 		if (is_sysenter(vcpu)) {
+			printk(KERN_DEBUG "handle_exception: sysenter");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 				if (nitro_should_propagate(vcpu)) {
-					printk(KERN_DEBUG "handle_exception: filling nitro.event from with sysenter");
-					vcpu->nitro.event.present = true;
-					vcpu->nitro.event.type = SYSENTER;
-					vcpu->nitro.event.direction = ENTER;
-					kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-					kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-					vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN;
+					nitro_fill_event(vcpu, SYSENTER, ENTER);
 					return 0;
 				} else {
 					nitro_do_continue(vcpu);
@@ -5577,22 +5556,13 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 				}
 			}
 		} else if (is_sysexit(vcpu)) {
+			printk(KERN_DEBUG "handle_exception: sysexit");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
+				nitro_do_continue(vcpu);
 				if (nitro_should_propagate(vcpu)) {
-					// These are likely to be wrong since the original implementation filled
-					// the event info after emulating the instruction. I guess we kind of
-					// need to do that here but without affecting the actual state of the
-					// vcpu, or somehow fill the event data later
-					printk(KERN_DEBUG "handle_exception: filling nitro.event from with sysexit");
-					vcpu->nitro.event.present = true;
-					vcpu->nitro.event.type = SYSENTER;
-					vcpu->nitro.event.direction = EXIT;
-					kvm_arch_vcpu_ioctl_get_regs(vcpu, &(vcpu->nitro.event.regs));
-					kvm_arch_vcpu_ioctl_get_sregs(vcpu, &(vcpu->nitro.event.sregs));
-					vcpu->run->exit_reason = KVM_EXIT_IRQ_WINDOW_OPEN;
+					nitro_fill_event(vcpu, SYSENTER, EXIT);
 					return 0;
 				} else {
-					nitro_do_continue(vcpu);
 					return 1;
 				}
 			}

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5505,6 +5505,12 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			kvm_queue_exception(vcpu, UD_VECTOR);
 			return 1;
 		}
+		if (is_syscall(vcpu)) {
+			printk("handle_exception on syscall");
+		} else if (is_sysret(vcpu)) {
+			printk("handle_exception on sysret");
+		}
+
 		er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
 		if (er != EMULATE_DONE)
 			kvm_queue_exception(vcpu, UD_VECTOR);
@@ -5520,6 +5526,12 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 	{
 		if (is_sysenter_sysexit(vcpu))
 		{
+			if (is_sysenter(vcpu)) {
+				printk("handle_exception on sysenter");
+			} else if (is_sysexit(vcpu)) {
+				printk("handle_exception on sysexit");
+			}
+
 			er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
 			if (er != EMULATE_DONE)
 				kvm_queue_exception(vcpu, UD_VECTOR);

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5508,7 +5508,7 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 		if (is_syscall(vcpu)) {
 			printk("handle_exception on syscall");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-				printk("filling nitro.event from handle_exception");
+				printk("filling nitro.event from handle_exception with ENTER");
 				vcpu->nitro.event.present = true;
 				vcpu->nitro.event.type = SYSCALL;
 				vcpu->nitro.event.direction = ENTER;
@@ -5521,7 +5521,7 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 		} else if (is_sysret(vcpu)) {
 			printk("handle_exception on sysret");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-				printk("filling nitro.event from handle_exception");
+				printk("filling nitro.event from handle_exception with EXIT");
 				vcpu->nitro.event.present = true;
 				vcpu->nitro.event.type = SYSCALL;
 				vcpu->nitro.event.direction = EXIT;

--- a/arch/x86/kvm/vmx.c
+++ b/arch/x86/kvm/vmx.c
@@ -5509,8 +5509,8 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 		if (is_syscall(vcpu)) {
 			printk(KERN_DEBUG "handle_exception: syscall");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-				if (nitro_should_propagate(vcpu)) {
-					printk("syscall propagated");
+				if (nitro_should_propagate(vcpu, ENTER)) {
+					printk(KERN_DEBUG "syscall propagated");
 					nitro_fill_event(vcpu, SYSCALL, ENTER);
 					return 0;
 				} else {
@@ -5522,8 +5522,8 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			printk(KERN_DEBUG "handle_exception: sysret");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 				nitro_do_continue(vcpu);
-				if (nitro_should_propagate(vcpu)) {
-					printk("sysret propagated");
+				if (nitro_should_propagate(vcpu, EXIT)) {
+					printk(KERN_DEBUG "sysret propagated");
 					nitro_fill_event(vcpu, SYSCALL, EXIT);
 					return 0;
 				} else {
@@ -5547,7 +5547,8 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 		if (is_sysenter(vcpu)) {
 			printk(KERN_DEBUG "handle_exception: sysenter");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
-				if (nitro_should_propagate(vcpu)) {
+				if (nitro_should_propagate(vcpu, ENTER)) {
+					printk(KERN_DEBUG "sysenter propagated");
 					nitro_fill_event(vcpu, SYSENTER, ENTER);
 					return 0;
 				} else {
@@ -5559,7 +5560,8 @@ static int handle_exception(struct kvm_vcpu *vcpu)
 			printk(KERN_DEBUG "handle_exception: sysexit");
 			if(nitro_is_trap_set(vcpu->kvm, NITRO_TRAP_SYSCALL)){
 				nitro_do_continue(vcpu);
-				if (nitro_should_propagate(vcpu)) {
+				if (nitro_should_propagate(vcpu, EXIT)) {
+					printk(KERN_DEBUG "sysexit propagated");
 					nitro_fill_event(vcpu, SYSENTER, EXIT);
 					return 0;
 				} else {

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -8512,6 +8512,25 @@ int kvm_arch_update_irqfd_routing(struct kvm *kvm, unsigned int host_irq,
 
 int x86_decode_insn(struct x86_emulate_ctxt *ctxt, void *insn, int insn_len);
 
+int is_syscall_sysenter(struct kvm_vcpu* vcpu)
+{
+	struct x86_emulate_ctxt *ctxt;
+	int r = 0;
+
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
+
+	r = x86_decode_insn(ctxt, NULL, 0);
+
+	if (ctxt->opcode_len == 2 &&  (ctxt->b == 0x34 || ctxt->b == 0x05))
+		return 1;
+	else {
+		printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
+		return 0;
+	}
+}
+EXPORT_SYMBOL_GPL(is_syscall_sysenter);
+
 int is_sysenter_sysexit(struct kvm_vcpu* vcpu)
 {
     struct x86_emulate_ctxt *ctxt;

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -8616,30 +8616,6 @@ int is_sysexit(struct kvm_vcpu* vcpu)
 }
 EXPORT_SYMBOL_GPL(is_sysexit);
 
-int is_syscall_sysenter(struct kvm_vcpu* vcpu)
-{
-	struct x86_emulate_ctxt *ctxt;
-	int r = 0;
-
-	init_emulate_ctxt(vcpu);
-	ctxt = &vcpu->arch.emulate_ctxt;
-
-	r = x86_decode_insn(ctxt, NULL, 0);
-	if (r != X86EMUL_CONTINUE) {
-		printk(KERN_DEBUG "is_syscall_sysenter: x86_decode_insn returned %d", r);
-	}
-
-	if (ctxt->opcode_len == 2 && (ctxt->b == 0x34 || ctxt->b == 0x5))
-		return 1;
-	else
-		{
-			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-			return 0;
-		}
-}
-EXPORT_SYMBOL_GPL(is_syscall_sysenter);
-
-
 bool kvm_vector_hashing_enabled(void)
 {
 	return vector_hashing;

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6849,11 +6849,17 @@ static inline bool kvm_vcpu_running(struct kvm_vcpu *vcpu)
 }
 
 static int vcpu_run(struct kvm_vcpu *vcpu)
+
 {
 	int r;
 	struct kvm *kvm = vcpu->kvm;
 
 	vcpu->srcu_idx = srcu_read_lock(&kvm->srcu);
+
+	/* if(vcpu->nitro.event.present) { */
+	/* 	printk(KERN_DEBUG "vcpu_run called with nitro event present"); */
+	/* 	nitro_process_event(vcpu); */
+	/* } */
 
 	for (;;) {
 		if (kvm_vcpu_running(vcpu)) {
@@ -6865,9 +6871,6 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 		if (r <= 0)
 			break;
 		
-
-		if(vcpu->nitro.event.present)
-			nitro_process_event(vcpu);
 
 		clear_bit(KVM_REQ_PENDING_TIMER, &vcpu->requests);
 		if (kvm_cpu_has_pending_timer(vcpu))
@@ -7066,6 +7069,7 @@ int kvm_arch_vcpu_ioctl_get_regs(struct kvm_vcpu *vcpu, struct kvm_regs *regs)
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(kvm_arch_vcpu_ioctl_get_regs);
 
 int kvm_arch_vcpu_ioctl_set_regs(struct kvm_vcpu *vcpu, struct kvm_regs *regs)
 {
@@ -7149,6 +7153,7 @@ int kvm_arch_vcpu_ioctl_get_sregs(struct kvm_vcpu *vcpu,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(kvm_arch_vcpu_ioctl_get_sregs);
 
 int kvm_arch_vcpu_ioctl_get_mpstate(struct kvm_vcpu *vcpu,
 				    struct kvm_mp_state *mp_state)

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6867,7 +6867,6 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 		
 
 		if(vcpu->nitro.event.present) {
-			printk("vcpu_run calling nitro_process_event");
 			nitro_process_event(vcpu);
 		}
 
@@ -8535,6 +8534,87 @@ int is_sysenter_sysexit(struct kvm_vcpu* vcpu)
 }
 EXPORT_SYMBOL_GPL(is_sysenter_sysexit);
 
+int is_syscall(struct kvm_vcpu* vcpu)
+{
+	struct x86_emulate_ctxt *ctxt;
+	int r = 0;
+
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
+
+	r = x86_decode_insn(ctxt, NULL, 0);
+
+	if (ctxt->opcode_len == 2 && ctxt->b == 0x5)
+		return 1;
+	else
+		{
+			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
+			return 0;
+		}
+}
+EXPORT_SYMBOL_GPL(is_syscall);
+
+int is_sysret(struct kvm_vcpu* vcpu)
+{
+	struct x86_emulate_ctxt *ctxt;
+	int r = 0;
+
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
+
+	r = x86_decode_insn(ctxt, NULL, 0);
+
+	if (ctxt->opcode_len == 2 && ctxt->b == 0x7)
+		return 1;
+	else
+		{
+			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
+			return 0;
+		}
+}
+EXPORT_SYMBOL_GPL(is_sysret);
+
+int is_sysenter(struct kvm_vcpu* vcpu)
+{
+	struct x86_emulate_ctxt *ctxt;
+	int r = 0;
+
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
+
+	r = x86_decode_insn(ctxt, NULL, 0);
+
+	if (ctxt->opcode_len == 2 && ctxt->b == 0x34)
+		return 1;
+	else
+		{
+			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
+			return 0;
+		}
+}
+EXPORT_SYMBOL_GPL(is_sysenter);
+
+
+int is_sysexit(struct kvm_vcpu* vcpu)
+{
+	struct x86_emulate_ctxt *ctxt;
+	int r = 0;
+
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
+
+	r = x86_decode_insn(ctxt, NULL, 0);
+
+	if (ctxt->opcode_len == 2 && ctxt->b == 0x35)
+		return 1;
+	else
+		{
+			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
+			return 0;
+		}
+}
+EXPORT_SYMBOL_GPL(is_sysexit);
+
 int is_syscall_sysenter(struct kvm_vcpu* vcpu)
 {
 	struct x86_emulate_ctxt *ctxt;
@@ -8545,7 +8625,7 @@ int is_syscall_sysenter(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 1 && (ctxt->b == 0x34 || ctxt->b == 0x5))
+	if (ctxt->opcode_len == 2 && (ctxt->b == 0x34 || ctxt->b == 0x5))
 		return 1;
 	else
 		{

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6862,8 +6862,9 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 
 	for (;;) {
 		if(vcpu->nitro.event.present) {
-			nitro_process_event(vcpu);
-			printk("vcpu_run got past nitro_process_event");
+			nitro_wait(vcpu);
+			vcpu->nitro.event.present = false;
+			printk(KERN_DEBUG "vcpu_run: nitro_event handled");
 		}
 
 		if (kvm_vcpu_running(vcpu)) {

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -5551,15 +5551,6 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu,
 		++vcpu->stat.insn_emulation;
 		if (r != EMULATION_OK)  {
 			if (emulation_type & EMULTYPE_TRAP_UD) {
-				char *type;
-				switch (r) {
-				case EMULATION_OK: type = "EMULATION_OK"; break;
-				case EMULATION_FAILED: type = "EMULATION_FAILED"; break;
-				case EMULATION_RESTART: type = "EMULATION_RESTART"; break;
-				case EMULATION_INTERCEPTED: type = "EMULATION_INTERCEPTED"; break;
-				default: type = "unknown"; break;
-				}
-				printk("x86_emulate_instruction: x86_decode_insn failed with %s", type);
 				return EMULATE_FAIL;
 			}
 			if (reexecute_instruction(vcpu, cr2, write_fault_to_spt,

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6850,17 +6850,13 @@ static inline bool kvm_vcpu_running(struct kvm_vcpu *vcpu)
 
 static int vcpu_run(struct kvm_vcpu *vcpu)
 {
-	int r, er;
+	int r;
 	struct kvm *kvm = vcpu->kvm;
 
 	vcpu->srcu_idx = srcu_read_lock(&kvm->srcu);
 
 	for (;;) {
 		if(vcpu->nitro.event.present) {
-			er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
-			if (er != EMULATE_DONE) {
-				printk("vcpu_run syscall/sysret emulation != EMULATION_DONE");
-			}
 			nitro_process_event(vcpu);
 		}
 
@@ -8552,13 +8548,7 @@ int is_syscall(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 2 && ctxt->b == 0x5)
-		return 1;
-	else
-		{
-			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-			return 0;
-		}
+	return (ctxt->opcode_len == 2 && ctxt->b == 0x5);
 }
 EXPORT_SYMBOL_GPL(is_syscall);
 
@@ -8572,13 +8562,7 @@ int is_sysret(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 2 && ctxt->b == 0x7)
-		return 1;
-	else
-		{
-			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-			return 0;
-		}
+	return (ctxt->opcode_len == 2 && ctxt->b == 0x7);
 }
 EXPORT_SYMBOL_GPL(is_sysret);
 
@@ -8592,13 +8576,7 @@ int is_sysenter(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 2 && ctxt->b == 0x34)
-		return 1;
-	else
-		{
-			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-			return 0;
-		}
+	return (ctxt->opcode_len == 2 && ctxt->b == 0x34);
 }
 EXPORT_SYMBOL_GPL(is_sysenter);
 
@@ -8613,13 +8591,7 @@ int is_sysexit(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 2 && ctxt->b == 0x35)
-		return 1;
-	else
-		{
-			printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-			return 0;
-		}
+	return (ctxt->opcode_len == 2 && ctxt->b == 0x35);
 }
 EXPORT_SYMBOL_GPL(is_sysexit);
 

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -8557,7 +8557,7 @@ int is_syscall(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 	if (r != X86EMUL_CONTINUE) {
-		printk("is_syscall: x86_decode_insn returned %d", r);
+		printk(KERN_DEBUG "is_syscall: x86_decode_insn returned %d", r);
 	}
 
 	return (ctxt->opcode_len == 2 && ctxt->b == 0x5);
@@ -8574,7 +8574,7 @@ int is_sysret(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 	if (r != X86EMUL_CONTINUE) {
-		printk("is_sysret: x86_decode_insn returned %d", r);
+		printk(KERN_DEBUG "is_sysret: x86_decode_insn returned %d", r);
 	}
 
 	return (ctxt->opcode_len == 2 && ctxt->b == 0x7);
@@ -8591,13 +8591,12 @@ int is_sysenter(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 	if (r != X86EMUL_CONTINUE) {
-		printk("is_sysenter: x86_decode_insn returned %d", r);
+		printk(KERN_DEBUG "is_sysenter: x86_decode_insn returned %d", r);
 	}
 
 	return (ctxt->opcode_len == 2 && ctxt->b == 0x34);
 }
 EXPORT_SYMBOL_GPL(is_sysenter);
-
 
 int is_sysexit(struct kvm_vcpu* vcpu)
 {
@@ -8609,9 +8608,8 @@ int is_sysexit(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 	if (r != X86EMUL_CONTINUE) {
-		printk("is_sysexit: x86_decode_insn returned %d", r);
+		printk(KERN_DEBUG "is_sysexit: x86_decode_insn returned %d", r);
 	}
-
 
 	return (ctxt->opcode_len == 2 && ctxt->b == 0x35);
 }
@@ -8627,7 +8625,7 @@ int is_syscall_sysenter(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 	if (r != X86EMUL_CONTINUE) {
-		printk("is_syscall_sysenter: x86_decode_insn returned %d", r);
+		printk(KERN_DEBUG "is_syscall_sysenter: x86_decode_insn returned %d", r);
 	}
 
 	if (ctxt->opcode_len == 2 && (ctxt->b == 0x34 || ctxt->b == 0x5))

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6853,8 +6853,6 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 	int r;
 	struct kvm *kvm = vcpu->kvm;
 
-	printk("vcpu run called");
-
 	vcpu->srcu_idx = srcu_read_lock(&kvm->srcu);
 
 	for (;;) {
@@ -6868,8 +6866,10 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 			break;
 		
 
-		if(vcpu->nitro.event.present)
+		if(vcpu->nitro.event.present) {
+			printk("vcpu_run calling nitro_process_event");
 			nitro_process_event(vcpu);
+		}
 
 		clear_bit(KVM_REQ_PENDING_TIMER, &vcpu->requests);
 		if (kvm_cpu_has_pending_timer(vcpu))

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -6867,7 +6867,7 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
 		
 
 		if(vcpu->nitro.event.present)
-			nitro_report_event(vcpu);
+			nitro_process_event(vcpu);
 
 		clear_bit(KVM_REQ_PENDING_TIMER, &vcpu->requests);
 		if (kvm_cpu_has_pending_timer(vcpu))

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -8522,9 +8522,11 @@ int is_syscall_sysenter(struct kvm_vcpu* vcpu)
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
-	if (ctxt->opcode_len == 2 &&  (ctxt->b == 0x34 || ctxt->b == 0x05))
+	printk(KERN_INFO "nitro: opcode info len=%d b=0x%x",
+				 ctxt->opcode_len, ctxt->b);
+	if (ctxt->opcode_len == 1 && (ctxt->b == 0x34 || ctxt->b == 0x5)) {
 		return 1;
-	else {
+	} else {
 		printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
 		return 0;
 	}
@@ -8533,21 +8535,21 @@ EXPORT_SYMBOL_GPL(is_syscall_sysenter);
 
 int is_sysenter_sysexit(struct kvm_vcpu* vcpu)
 {
-    struct x86_emulate_ctxt *ctxt;
+	struct x86_emulate_ctxt *ctxt;
 	int r = 0;
 
-    init_emulate_ctxt(vcpu);
-    ctxt = &vcpu->arch.emulate_ctxt;
+	init_emulate_ctxt(vcpu);
+	ctxt = &vcpu->arch.emulate_ctxt;
 
 	r = x86_decode_insn(ctxt, NULL, 0);
 
 	// twobyte and SYSENTER/SYSEXIT
 	if (ctxt->opcode_len == 2 &&  (ctxt->b == 0x34 || ctxt->b == 0x35))
-        return 1;
-    else
+		return 1;
+	else
 	{
 		printk(KERN_INFO "nitro: opcode = 0x%x", ctxt->b);
-        return 0;
+		return 0;
 	}
 }
 EXPORT_SYMBOL_GPL(is_sysenter_sysexit);

--- a/arch/x86/kvm/x86.h
+++ b/arch/x86/kvm/x86.h
@@ -215,3 +215,4 @@ static inline u64 nsec_to_cycles(struct kvm_vcpu *vcpu, u64 nsec)
 #endif
 
 int is_sysenter_sysexit(struct kvm_vcpu* vcpu);
+int is_syscall_sysenter(struct kvm_vcpu* vcpu);

--- a/arch/x86/kvm/x86.h
+++ b/arch/x86/kvm/x86.h
@@ -214,6 +214,8 @@ static inline u64 nsec_to_cycles(struct kvm_vcpu *vcpu, u64 nsec)
 
 #endif
 
+void init_emulate_ctxt(struct kvm_vcpu *vcpu);
+
 int is_sysenter_sysexit(struct kvm_vcpu* vcpu);
 int is_syscall_sysenter(struct kvm_vcpu* vcpu);
 int is_syscall(struct kvm_vcpu* vcpu);

--- a/arch/x86/kvm/x86.h
+++ b/arch/x86/kvm/x86.h
@@ -216,8 +216,6 @@ static inline u64 nsec_to_cycles(struct kvm_vcpu *vcpu, u64 nsec)
 
 void init_emulate_ctxt(struct kvm_vcpu *vcpu);
 
-int is_sysenter_sysexit(struct kvm_vcpu* vcpu);
-int is_syscall_sysenter(struct kvm_vcpu* vcpu);
 int is_syscall(struct kvm_vcpu* vcpu);
 int is_sysret(struct kvm_vcpu* vcpu);
 int is_sysenter(struct kvm_vcpu* vcpu);

--- a/arch/x86/kvm/x86.h
+++ b/arch/x86/kvm/x86.h
@@ -216,3 +216,7 @@ static inline u64 nsec_to_cycles(struct kvm_vcpu *vcpu, u64 nsec)
 
 int is_sysenter_sysexit(struct kvm_vcpu* vcpu);
 int is_syscall_sysenter(struct kvm_vcpu* vcpu);
+int is_syscall(struct kvm_vcpu* vcpu);
+int is_sysret(struct kvm_vcpu* vcpu);
+int is_sysenter(struct kvm_vcpu* vcpu);
+int is_sysexit(struct kvm_vcpu* vcpu);

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -43,6 +43,7 @@ struct nitro_vcpus{
 //VM functions
 #define KVM_NITRO_ATTACH_VCPUS	_IOR(KVMIO, 0xE2, struct nitro_vcpus)
 #define KVM_NITRO_SET_SYSCALL_TRAP _IOW(KVMIO, 0xE3, bool)
+#define KVM_NITRO_ADD_SYSCALL_FILTER	_IOR(KVMIO, 0xEB, uint64_t)
 
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, struct event)

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -44,6 +44,7 @@ struct nitro_vcpus{
 #define KVM_NITRO_ATTACH_VCPUS	_IOR(KVMIO, 0xE2, struct nitro_vcpus)
 #define KVM_NITRO_SET_SYSCALL_TRAP _IOW(KVMIO, 0xE3, bool)
 #define KVM_NITRO_ADD_SYSCALL_FILTER	_IOR(KVMIO, 0xEB, uint64_t)
+#define KVM_NITRO_REMOVE_SYSCALL_FILTER	_IOR(KVMIO, 0xEC, uint64_t)
 
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, struct event)

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -49,6 +49,7 @@ struct nitro_vcpus{
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, struct event)
 #define KVM_NITRO_CONTINUE	_IO(KVMIO, 0xE6)
+#define KVM_NITRO_CONTINUE_STEP_OVER	_IO(KVMIO, 0xEB)
 
 #define KVM_NITRO_GET_REGS              _IOR(KVMIO,  0xE7, struct kvm_regs)
 #define KVM_NITRO_SET_REGS              _IOW(KVMIO,  0xE8, struct kvm_regs)

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -9,6 +9,7 @@
 
 #define NITRO_TRAP_SYSCALL 1UL
 
+// 12 bits -> 1024 entries
 #define NITRO_SYSCALL_FILTER_HT_BITS 12
 
 struct syscall_stack_item
@@ -17,6 +18,9 @@ struct syscall_stack_item
 	struct list_head list;
 };
 
+// empty entry for the syscall hashtable
+// we only need the hashtable to get a O(1) access and
+// check if a syscall is present in the filter
 struct syscall_filter_ht_entry
 {
 	struct hlist_node node;

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -31,11 +31,17 @@ struct nitro{
   DECLARE_HASHTABLE(syscall_filter_ht, NITRO_SYSCALL_FILTER_HT_BITS);
 };
 
+enum nitro_continuation {
+  NITRO_CONTINUATION_CONTINUE,
+  NITRO_CONTINUATION_STEP_OVER
+};
+
 struct nitro_vcpu{
   struct completion k_wait_cv;
   struct semaphore n_wait_sem;
   struct event event;
   struct syscall_stack_item stack;
+  enum nitro_continuation cont;
 };
 
 struct kvm* nitro_get_vm_by_creator(pid_t);

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -45,6 +45,7 @@ struct nitro_vcpu{
 };
 
 struct kvm* nitro_get_vm_by_creator(pid_t);
+void nitro_fill_event(struct kvm_vcpu *vcpu, enum syscall_type type, enum syscall_direction direction);
 
 int nitro_iotcl_num_vms(void);
 int nitro_iotcl_attach_vcpus(struct kvm*, struct nitro_vcpus*);

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -45,6 +45,7 @@ int nitro_ioctl_continue(struct kvm_vcpu*);
 
 int nitro_is_trap_set(struct kvm*, uint32_t);
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
+int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
 bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -1,6 +1,7 @@
 #ifndef NITRO_MAIN_H_
 #define NITRO_MAIN_H_
 
+#include <linux/hashtable.h>
 #include <linux/list.h>
 #include <linux/types.h>
 #include <linux/kvm_host.h>
@@ -8,7 +9,7 @@
 
 #define NITRO_TRAP_SYSCALL 1UL
 
-#define NITRO_SYSCALL_FILTER_MAX 1024
+#define NITRO_SYSCALL_FILTER_HT_BITS 12
 
 struct syscall_stack_item
 {
@@ -16,10 +17,14 @@ struct syscall_stack_item
 	struct list_head list;
 };
 
+struct syscall_filter_ht_entry
+{
+	struct hlist_node node;
+};
+
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
-  uint64_t syscall_filter[NITRO_SYSCALL_FILTER_MAX];
-  int syscall_filter_size;
+  DECLARE_HASHTABLE(syscall_filter_ht, NITRO_SYSCALL_FILTER_HT_BITS);
 };
 
 struct nitro_vcpu{
@@ -46,6 +51,7 @@ int nitro_ioctl_continue(struct kvm_vcpu*);
 int nitro_is_trap_set(struct kvm*, uint32_t);
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
 int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
-bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
+int nitro_clear_syscall_filter(struct kvm *kvm);
+struct syscall_filter_ht_entry* nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -18,7 +18,7 @@ struct syscall_stack_item
 
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
-  uint64_t syscall_filter[1024];
+  uint64_t syscall_filter[NITRO_SYSCALL_FILTER_MAX];
   int syscall_filter_size;
 };
 

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -7,16 +7,26 @@
 #include <linux/nitro.h>
 
 #define NITRO_TRAP_SYSCALL 1UL
-//#define NITRO_TRAP_XYZ  (1UL << 1)
+
+#define NITRO_SYSCALL_FILTER_MAX 1024
+
+struct syscall_stack_item
+{
+	uint64_t syscall_nb;
+	struct list_head list;
+};
 
 struct nitro{
   uint32_t traps; //determines whether the syscall trap is globally set
+  uint64_t syscall_filter[1024];
+  int syscall_filter_size;
 };
 
 struct nitro_vcpu{
   struct completion k_wait_cv;
   struct semaphore n_wait_sem;
   struct event event;
+  struct syscall_stack_item stack;
 };
 
 struct kvm* nitro_get_vm_by_creator(pid_t);
@@ -34,6 +44,7 @@ int nitro_ioctl_get_event(struct kvm_vcpu*, struct event *ev);
 int nitro_ioctl_continue(struct kvm_vcpu*);
 
 int nitro_is_trap_set(struct kvm*, uint32_t);
-
+int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);
+bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb);
 
 #endif //NITRO_MAIN_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -51,6 +51,7 @@ void nitro_destroy_vcpu_hook(struct kvm_vcpu*);
 
 int nitro_ioctl_get_event(struct kvm_vcpu*, struct event *ev);
 int nitro_ioctl_continue(struct kvm_vcpu*);
+int nitro_ioctl_continue_step_over(struct kvm_vcpu *);
 
 int nitro_is_trap_set(struct kvm*, uint32_t);
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb);

--- a/include/uapi/linux/kvm.h
+++ b/include/uapi/linux/kvm.h
@@ -206,6 +206,7 @@ struct kvm_hyperv_exit {
 #define KVM_EXIT_IOAPIC_EOI       26
 #define KVM_EXIT_HYPERV           27
 
+
 /* For KVM_EXIT_INTERNAL_ERROR */
 /* Emulate instruction failed. */
 #define KVM_INTERNAL_ERROR_EMULATION	1

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -3200,6 +3200,15 @@ out_free_irq_routing:
 		r = 0;
 		break;
 	}
+	case KVM_NITRO_ADD_SYSCALL_FILTER: {
+		uint64_t syscall_nb;
+		r = -EFAULT;
+		if (copy_from_user(&syscall_nb, argp, sizeof(uint64_t)))
+			goto out;
+
+		r = nitro_add_syscall_filter(kvm, syscall_nb);
+		break;
+	}
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -3209,6 +3209,15 @@ out_free_irq_routing:
 		r = nitro_add_syscall_filter(kvm, syscall_nb);
 		break;
 	}
+	case KVM_NITRO_REMOVE_SYSCALL_FILTER: {
+		uint64_t syscall_nb;
+		r = -EFAULT;
+		if (copy_from_user(&syscall_nb, argp, sizeof(uint64_t)))
+			goto out;
+
+		r = nitro_remove_syscall_filter(kvm, syscall_nb);
+		break;
+	}
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -2558,6 +2558,9 @@ static long kvm_vcpu_ioctl(struct file *filp,
 	case KVM_NITRO_CONTINUE:
 		r = nitro_ioctl_continue(vcpu);
 		goto out_no_put;
+	case KVM_NITRO_CONTINUE_STEP_OVER:
+		r = nitro_ioctl_continue_step_over(vcpu);
+		goto out_no_put;
 	case KVM_NITRO_GET_REGS: {
 		struct kvm_regs *kvm_regs;
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -194,13 +194,15 @@ int nitro_clear_syscall_filter(struct kvm *kvm)
 struct syscall_filter_ht_entry* nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb)
 {
 	uint64_t key = syscall_nb;
-	struct syscall_filter_ht_entry *found;
+	struct syscall_filter_ht_entry *found = NULL;
 
+	mutex_lock(&kvm->lock);
 	hash_for_each_possible(kvm->nitro.syscall_filter_ht, found, node, key)
 	{
-		return found;
+		break;
 	}
+	mutex_unlock(&kvm->lock);
 
-	return NULL;
+	return found;
 }
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -87,7 +87,7 @@ int nitro_iotcl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
     kvm_get_kvm(kvm);
     nvcpus->fds[r] = create_vcpu_fd(v);
     if(nvcpus->fds[r]<0){
-      for(i=r;r>=0;i--){
+      for(i=r;i>=0;i--){
 	nvcpus->ids[i] = 0;
 	nvcpus->fds[i] = 0;
 	kvm_put_kvm(kvm);

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -98,9 +98,9 @@ int nitro_iotcl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
     nvcpus->fds[r] = create_vcpu_fd(v);
     if(nvcpus->fds[r]<0){
       for(i=r;i>=0;i--){
-	nvcpus->ids[i] = 0;
-	nvcpus->fds[i] = 0;
-	kvm_put_kvm(kvm);
+        nvcpus->ids[i] = 0;
+        nvcpus->fds[i] = 0;
+        kvm_put_kvm(kvm);
       }
       goto error_out;
     }
@@ -109,7 +109,7 @@ int nitro_iotcl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
   mutex_unlock(&kvm->lock);
   return 0;
   
-error_out:
+ error_out:
   mutex_unlock(&kvm->lock);
   return -1;
 }
@@ -118,7 +118,7 @@ int nitro_ioctl_get_event(struct kvm_vcpu *vcpu, struct event *ev){
   int rv;
   
   rv = down_timeout(&(vcpu->nitro.n_wait_sem), 1000);
-  printk("nitro_ioctl_get_event past down(n_wait_sem)");
+  printk(KERN_DEBUG "nitro_ioctl_get_event: past down");
   
   if (rv == 0) {
 	  ev->direction = vcpu->nitro.event.direction;
@@ -126,17 +126,15 @@ int nitro_ioctl_get_event(struct kvm_vcpu *vcpu, struct event *ev){
 	  ev->regs = vcpu->nitro.event.regs;
 	  ev->sregs = vcpu->nitro.event.sregs;
   } else {
-    printk("nitro_ioctl_get_event returned non-zero value");
+    printk(KERN_INFO "nitro_ioctl_get_event: returned non-zero value");
   }
   
   return rv;
 }
 
 int nitro_ioctl_continue(struct kvm_vcpu *vcpu) {
-  int er;
-  printk("nitro_ioctl_continue called");
+  printk(KERN_DEBUG "nitro_ioctl_continue: continuing");
 
-	// if no waiters
 	if(completion_done(&(vcpu->nitro.k_wait_cv)))
     return -1;
 
@@ -148,9 +146,7 @@ int nitro_ioctl_continue(struct kvm_vcpu *vcpu) {
 }
 
 int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
-  unsigned long rip;
-
-  printk(KERN_INFO "nitro: stepping over system call invocation...");
+  printk(KERN_DEBUG "nitro_ioctl_continue_step_over: stepping over system call invocation");
 
   if(completion_done(&(vcpu->nitro.k_wait_cv)))
     return -1;

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -140,11 +140,7 @@ int nitro_ioctl_continue(struct kvm_vcpu *vcpu) {
 	if(completion_done(&(vcpu->nitro.k_wait_cv)))
     return -1;
 
-  er = emulate_instruction(vcpu, EMULTYPE_TRAP_UD);
-  if (er != EMULATE_DONE) {
-    printk("nitro_ioctl_continue syscall/sysret emulation != EMULATION_DONE");
-    kvm_queue_exception(vcpu, UD_VECTOR);
-  }
+  vcpu->nitro.cont = NITRO_CONTINUATION_CONTINUE;
 
 	complete(&(vcpu->nitro.k_wait_cv));
 
@@ -159,20 +155,10 @@ int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
   if(completion_done(&(vcpu->nitro.k_wait_cv)))
     return -1;
 
-  /* if (!is_syscall_sysenter(vcpu)) */
-  /*   return -1; */
-
-  printk(KERN_INFO "nitro: found syscall or sysenter");
-
-  // Both SYSCALL and SYSENTER are two bytes
-  rip = kvm_rip_read(vcpu);
-  printk(KERN_INFO "original rip: %lu", rip);
-  rip += 2; 
-  kvm_rip_write(vcpu, rip);
-
-  printk(KERN_INFO "nitro: skipped");
+  vcpu->nitro.cont = NITRO_CONTINUATION_STEP_OVER;
 
   complete(&(vcpu->nitro.k_wait_cv));
+
   return 0;
 }
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -129,12 +129,11 @@ int nitro_ioctl_get_event(struct kvm_vcpu *vcpu, struct event *ev){
   return rv;
 }
 
-int nitro_ioctl_continue(struct kvm_vcpu *vcpu){
+int nitro_ioctl_continue(struct kvm_vcpu *vcpu) {
 
 	// if no waiters
 	if(completion_done(&(vcpu->nitro.k_wait_cv)))
-		return -1;
-
+    return -1;
 	complete(&(vcpu->nitro.k_wait_cv));
 
 	return 0;
@@ -153,17 +152,10 @@ int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
 
   printk(KERN_INFO "nitro: found syscall or sysenter");
 
-  // Should we do something with these
-	/* vcpu->arch.emulate_regs_need_sync_from_vcpu = true; */
-	/* vcpu->arch.emulate_regs_need_sync_to_vcpu = false; */
-
   // Both SYSCALL and SYSENTER are two bytes
   rip = kvm_rip_read(vcpu);
-
   printk(KERN_INFO "original rip: %lu", rip);
-
   rip += 2; 
-
   kvm_rip_write(vcpu, rip);
 
   printk(KERN_INFO "nitro: skipped");
@@ -175,6 +167,7 @@ int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
 int nitro_is_trap_set(struct kvm *kvm, uint32_t trap){
   return kvm->nitro.traps & trap;
 }
+EXPORT_SYMBOL_GPL(nitro_is_trap_set);
 
 int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 {

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -60,6 +60,9 @@ void nitro_destroy_vcpu_hook(struct kvm_vcpu *vcpu){
 	struct list_head *pos, *n;
 
 	vcpu->nitro.event.present = false;
+  // Not sure if this is safe
+  complete_all(&(vcpu->nitro.k_wait_cv));
+
 	// destroy vcpu syscall stack
 	list_for_each_safe(pos, n, &vcpu->nitro.stack.list)
 	{

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -59,7 +59,16 @@ void nitro_create_vcpu_hook(struct kvm_vcpu *vcpu){
 }
 
 void nitro_destroy_vcpu_hook(struct kvm_vcpu *vcpu){
-  vcpu->nitro.event.present = false;
+	vcpu->nitro.event.present = false;
+	// destroy vcpu syscall stack
+	struct syscall_stack_item *tmp;
+	struct list_head *pos, *n;
+	list_for_each_safe(pos, n, &vcpu->nitro.stack.list)
+	{
+		tmp = list_entry(pos, struct syscall_stack_item, list);
+		list_del(pos);
+		kfree(tmp);
+	}
 }
 
 int nitro_iotcl_num_vms(void){

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -146,6 +146,7 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 		if (kvm->nitro.syscall_filter[i] == syscall_nb)
 			return 0;
 
+	mutex_lock(&kvm->lock);
 	// insert
 	kvm->nitro.syscall_filter_size++;
 	if (kvm->nitro.syscall_filter_size > NITRO_SYSCALL_FILTER_MAX)
@@ -156,6 +157,7 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 	}
 	int index = kvm->nitro.syscall_filter_size - 1;
 	kvm->nitro.syscall_filter[index] = syscall_nb;
+	mutex_unlock(&kvm->lock);
 	return 0;
 }
 
@@ -171,6 +173,7 @@ int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 		}
 	if (found == true)
 	{
+		mutex_lock(&kvm->lock);
 		int j;
 		for (j = i + 1; j < kvm->nitro.syscall_filter_size; j++)
 		{
@@ -178,7 +181,10 @@ int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 			kvm->nitro.syscall_filter[j-1] = kvm->nitro.syscall_filter[j];
 		}
 		kvm->nitro.syscall_filter_size--;
+		mutex_unlock(&kvm->lock);
 	}
+
+
 	return 0;
 }
 

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -159,6 +159,29 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 	return 0;
 }
 
+int nitro_remove_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
+{
+	int i;
+	bool found = false;
+	for (i = 0; i < kvm->nitro.syscall_filter_size; i++)
+		if (kvm->nitro.syscall_filter[i] == syscall_nb)
+		{
+			found = true;
+			break;
+		}
+	if (found == true)
+	{
+		int j;
+		for (j = i + 1; j < kvm->nitro.syscall_filter_size; j++)
+		{
+			// copy
+			kvm->nitro.syscall_filter[j-1] = kvm->nitro.syscall_filter[j];
+		}
+		kvm->nitro.syscall_filter_size--;
+	}
+	return 0;
+}
+
 bool nitro_find_syscall(struct kvm* kvm, uint64_t syscall_nb)
 {
 	int i;

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -141,9 +141,9 @@ int nitro_ioctl_continue(struct kvm_vcpu *vcpu){
 }
 
 int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
-  unsigned long new_rip;
+  unsigned long rip;
 
-  printk(KERN_INFO "nitro: stepping over system call invocation");
+  printk(KERN_INFO "nitro: stepping over system call invocation...");
 
   if(completion_done(&(vcpu->nitro.k_wait_cv)))
     return -1;
@@ -151,9 +151,22 @@ int nitro_ioctl_continue_step_over(struct kvm_vcpu *vcpu){
   if (!is_syscall_sysenter(vcpu))
     return -1;
 
+  printk(KERN_INFO "nitro: found syscall or sysenter");
+
+  // Should we do something with these
+	/* vcpu->arch.emulate_regs_need_sync_from_vcpu = true; */
+	/* vcpu->arch.emulate_regs_need_sync_to_vcpu = false; */
+
   // Both SYSCALL and SYSENTER are two bytes
-  new_rip = kvm_rip_read(vcpu) + 2;
-  kvm_rip_write(vcpu, new_rip);
+  rip = kvm_rip_read(vcpu);
+
+  printk(KERN_INFO "original rip: %lu", rip);
+
+  rip += 2; 
+
+  kvm_rip_write(vcpu, rip);
+
+  printk(KERN_INFO "nitro: skipped");
 
   complete(&(vcpu->nitro.k_wait_cv));
   return 0;

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -195,6 +195,7 @@ int nitro_add_syscall_filter(struct kvm *kvm, uint64_t syscall_nb)
 		found = kmalloc(sizeof(struct syscall_filter_ht_entry), GFP_KERNEL);
 		hash_add(kvm->nitro.syscall_filter_ht, &found->node, key);
 		mutex_unlock(&kvm->lock);
+    printk(KERN_DEBUG "nitro_add_syscall_filter: added %llu", syscall_nb);
 	}
 	return 0;
 }


### PR DESCRIPTION
So this is the patch set I've been working on, it is still quite experimental but it certainly seems promising.

I've rearchitectured the event handling pipeline to report system call entry events to the user space BEFORE they are executed. The system call exit events are still reported after they are executed to keep compatibility with the older behaviour. This patch introduces a new `CONTINUE_STEP_OVER` ioctl for stepping over system calls. Obviously this requires support from Nitro's user space components and I've created patches over there to support the functionality provided by this patch set.

What should be mostly working is stepping over system calls from syscall entry handlers in 64-bit binaries as well as continuing execution normally.

However, there are still a few problems with this. First, sysenter/sysret seems to be broken, the binaries using those instructions crash with segfaults. For me this is not a major problem for my use cases as Linux systems tend to be purely 64-bit. Also, the patch set does not play nicely with system call filtering but I've been actively working on figuring out why that is.

While I do not think this is in any state to be merged, I still opened this pull request to highlight the work I've been doing on this front.

![screenshot_20180222_171627](https://user-images.githubusercontent.com/40366/36849608-24e27d98-1d6d-11e8-93e6-a79127a949f0.png)
