### PR TITLE
kvm: introspection: avoid clash of syscall index for pidfd_mem

### DIFF
--- a/arch/x86/entry/syscalls/syscall_32.tbl
+++ b/arch/x86/entry/syscalls/syscall_32.tbl
@@ -440,4 +440,4 @@
 433	i386	fspick			sys_fspick			__ia32_sys_fspick
 434	i386	pidfd_open		sys_pidfd_open			__ia32_sys_pidfd_open
 435	i386	clone3			sys_clone3			__ia32_sys_clone3
-436	i386	pidfd_mem		sys_pidfd_mem			__ia32_sys_pidfd_mem
+999	i386	pidfd_mem		sys_pidfd_mem			__ia32_sys_pidfd_mem

--- a/arch/x86/entry/syscalls/syscall_64.tbl
+++ b/arch/x86/entry/syscalls/syscall_64.tbl
@@ -357,7 +357,7 @@
 433	common	fspick			__x64_sys_fspick
 434	common	pidfd_open		__x64_sys_pidfd_open
 435	common	clone3			__x64_sys_clone3/ptregs
-436	common	pidfd_mem		__x64_sys_pidfd_mem
+999	common	pidfd_mem		__x64_sys_pidfd_mem
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact

--- a/include/uapi/asm-generic/unistd.h
+++ b/include/uapi/asm-generic/unistd.h
@@ -850,7 +850,7 @@ __SYSCALL(__NR_pidfd_open, sys_pidfd_open)
 #define __NR_clone3 435
 __SYSCALL(__NR_clone3, sys_clone3)
 #endif
-#define __NR_pidfd_mem 436
+#define __NR_pidfd_mem 999
 __SYSCALL(__NR_pidfd_mem, sys_pidfd_mem)
 
 #undef __NR_syscalls

--- a/include/uapi/asm-generic/unistd.h
+++ b/include/uapi/asm-generic/unistd.h
@@ -854,7 +854,7 @@ __SYSCALL(__NR_clone3, sys_clone3)
 __SYSCALL(__NR_pidfd_mem, sys_pidfd_mem)
 
 #undef __NR_syscalls
-#define __NR_syscalls 436
+#define __NR_syscalls 1000
 
 /*
  * 32 bit systems traditionally used different


### PR DESCRIPTION
Linux 5.9 introduced the close_range syscall to effectively close multiple file descriptors at once.
Coincidentally, the index of this syscall is equal to the one of pidfd_mem.

As multiple programs, e.g., [systemd](https://github.com/systemd/systemd/blob/cbcf371abc328167fa869721c1add4850c793240/src/basic/fd-util.c#L211), attempt to use this syscall without checking against the kernel version, pidfd_mem breaks the boot process on many newer systems.

The patch proposes to move the syscall index far ahead to avoid potential future regressions until kvmi is merged upstream.