### PR TITLE
Prevent potential deadlock due to preemption while MTF is active

### DIFF
--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -8475,9 +8475,7 @@ static int vcpu_enter_guest(struct kvm_vcpu *vcpu)
 			goto out;
 		}
 
-		if (inject_pending_event(vcpu, req_int_win) != 0)
-			req_immediate_exit = true;
-		else {
+		if (!inject_pending_event(vcpu, req_int_win)) {
 			/* Enable SMI/NMI/IRQ window open exits if needed.
 			 *
 			 * SMIs have three cases:


### PR DESCRIPTION
When MTF is activated, it is possible to reach a sort-of deadlock where tens of thousands of vmexits occur with EXIT_REASON_PREEMPTION_TIMER.
This freezes the VM for a couple of seconds, which is undesirable.