### PR TITLE
Handle APIC timer during single-step

### DIFF
--- a/arch/x86/kvm/vmx/vmx.c
+++ b/arch/x86/kvm/vmx/vmx.c
@@ -6609,6 +6609,10 @@ static int vmx_sync_pir_to_irr(struct kvm_vcpu *vcpu)
 	struct vcpu_vmx *vmx = to_vmx(vcpu);
 	int max_irr;
 	bool max_irr_updated;
+	
+	if (kvmi_vcpu_running_singlestep(vcpu)) {
+		return -1;
+	}
 
 	WARN_ON(!vcpu->arch.apicv_active);
 	if (pi_test_on(&vmx->pi_desc)) {


### PR DESCRIPTION
We have noticed on some newer Intel machines, particularly on Xeon Gold, that the APIC clock interrupt almost always happens exactly during the single-step. This causes some problems with naive breakpoint implementations and, furthermore, causes a lot of unnecessary VM-exits.

Therefore, we suggest to delay this until exiting the single-step. Perhaps this warrants further discussion.