### PR TITLE
kvm: introspection: guest page mapping from host

### DIFF
--- a/Documentation/virt/kvm/kvmi.rst
+++ b/Documentation/virt/kvm/kvmi.rst
@@ -1554,6 +1554,36 @@ inside the current EPT view. Usage:
                 entries points to a MMIO region
 * -KVM_EAGAIN - internal KVM error: current root page table is invalid
 
+32. KVMI_VM_QUERY_PHYSICAL
+-------------------------
+
+:Architectures: all
+:Versions: >= 1
+:Parameters:
+
+::
+
+	struct kvmi_vm_query_physical {
+		__u64 gpa;
+	};
+
+:Returns:
+
+::
+
+	struct kvmi_error_code;
+	struct kvmi_vm_query_physical_reply {
+		__u64 gpa;
+		__u64 size;
+	};
+
+Retrieves starting gpa and size of memory slot belonging to query gpa.
+
+:Errors:
+
+* -KVM_EINVAL - the specified gpa is invalid
+* -KVM_ENOENT - the guest page doesn't exist
+
 Events
 ======
 

--- a/include/linux/kvmi_host.h
+++ b/include/linux/kvmi_host.h
@@ -8,6 +8,7 @@ struct kvm;
 struct kvm_vcpu;
 
 #include <asm/kvmi_host.h>
+#include <linux/proc_fs.h>
 
 #define KVMI_NUM_COMMANDS KVMI_NUM_MESSAGES
 
@@ -105,6 +106,8 @@ struct kvm_introspection {
 
 	bool cmd_reply_disabled;
 	bool cmd_reply_with_event;
+
+	struct proc_dir_entry *map;
 };
 
 #ifdef CONFIG_KVM_INTROSPECTION

--- a/include/uapi/linux/kvmi.h
+++ b/include/uapi/linux/kvmi.h
@@ -25,6 +25,7 @@ enum {
 	KVMI_VM_CONTROL_EVENTS   = 8,
 	KVMI_VM_READ_PHYSICAL    = 17,
 	KVMI_VM_WRITE_PHYSICAL   = 18,
+	KVMI_VM_QUERY_PHYSICAL   = 39,
 
 	KVMI_VCPU_GET_INFO         = 6,
 	KVMI_VCPU_PAUSE            = 7,
@@ -151,6 +152,15 @@ struct kvmi_vm_write_physical {
 	__u64 gpa;
 	__u64 size;
 	__u8  data[0];
+};
+
+struct kvmi_vm_query_physical {
+	__u64 gfn;
+};
+
+struct kvmi_vm_query_physical_reply {
+	__u64 gfn;
+	__u64 size;
 };
 
 struct kvmi_vcpu_hdr {

--- a/virt/kvm/introspection/kvmi_int.h
+++ b/virt/kvm/introspection/kvmi_int.h
@@ -56,6 +56,7 @@
 			| BIT(KVMI_VM_SET_PAGE_ACCESS) \
 			| BIT(KVMI_VM_SET_PAGE_SVE) \
 			| BIT(KVMI_VM_WRITE_PHYSICAL) \
+			| BIT(KVMI_VM_QUERY_PHYSICAL) \
 			| BIT(KVMI_VCPU_GET_INFO) \
 			| BIT(KVMI_VCPU_PAUSE) \
 			| BIT(KVMI_VCPU_CHANGE_GFN) \
@@ -171,6 +172,7 @@ int kvmi_cmd_read_physical(struct kvm *kvm, u64 gpa, u64 size,
 			   const struct kvmi_msg_hdr *ctx);
 int kvmi_cmd_write_physical(struct kvm *kvm, u64 gpa, u64 size,
 			    const void *buf);
+int kvmi_cmd_query_physical(struct kvm *kvm, u64 gfn, u64 *start, u64 *size);
 int kvmi_cmd_vcpu_pause(struct kvm_vcpu *vcpu, bool wait);
 int kvmi_cmd_vcpu_set_registers(struct kvm_vcpu *vcpu,
 				const struct kvm_regs *regs);


### PR DESCRIPTION
As discussed in https://github.com/KVM-VMI/kvm-vmi/issues/39#issuecomment-524815312, KVMi currently does not support mapping guest pages from the host.

This pull request implements this feature as follows:

1. We make a new entry in the ProcFS available during the virtual machine introspection. The introspection library uses this file in conjunction with `mmap`. We remap the resulting pages to the guest's pages, similar to https://github.com/KVM-VMI/kvm/commit/b7177c0fa9b39642c1670845b8cb1792ba0d53da. However, the fact that we are mapping the guest pages on the host allows for optimizations over the approach for remote mapping.
2. We add a new `KVMI_VM_QUERY_PHYSICAL` command that retrieves information about the backing memory slot for a given guest physical address. The idea behind this command is to enable seamless integration into libkvmi that can eventually provide a transparent API for page mapping (whether remote or host-local).

If this new functionality looks fine to you, I'm happy to send another pull request for integrating it into libkvmi and its caching system.

Best,
Thomas