### PR TITLE
kvm: introspection: fix suppressed page faults

### DIFF
--- a/virt/kvm/introspection/kvmi.c
+++ b/virt/kvm/introspection/kvmi.c
@@ -1311,7 +1311,7 @@ static bool kvmi_restricted_access(struct kvm_introspection *kvmi, gpa_t gpa,
 	if ((~allowed_access) & access) {
 		bool write_access = (access & KVMI_PAGE_ACCESS_W);
 
-		if (write_access && spp_access_allowed(gpa, allowed_bitmap))
+		if (write_access && kvmi_spp_enabled(kvmi) && spp_access_allowed(gpa, allowed_bitmap))
 			return false;
 
 		return true;


### PR DESCRIPTION
EPT violations on pages are filtered for sub-page write protection so that the introspection library only receives faults on the monitored sub-page.
While we ensure that the feature is enabled in practically all other locations of interest, `kvmi_restricted_access` does not perform this check.

This issue is especially troublesome if the application intends to change the page protection upon such an event. In my case, it caused over 8 million page faults (compared to around 500 after this fix).

I propose to add a check for the feature before using the bitmap.

Best,
Thomas