### PR TITLE
kvm: introspection: support FXSAVE long mode emulation

### DIFF
--- a/arch/x86/kvm/emulate.c
+++ b/arch/x86/kvm/emulate.c
@@ -4304,13 +4304,6 @@ static int check_fxsr(struct x86_emulate_ctxt *ctxt)
 	if (ctxt->ops->get_cr(ctxt, 0) & (X86_CR0_TS | X86_CR0_EM))
 		return emulate_nm(ctxt);
 
-	/*
-	 * Don't emulate a case that should never be hit, instead of working
-	 * around a lack of fxsave64/fxrstor64 on old compilers.
-	 */
-	if (ctxt->mode >= X86EMUL_MODE_PROT64)
-		return X86EMUL_UNHANDLEABLE;
-
 	return X86EMUL_CONTINUE;
 }
 


### PR DESCRIPTION
Upstream KVM opts not to emulate 64-bit `FXSAVE` / `FXRSTOR` for good reasons.
However, when we deal with self-inflicted EPT violations, emulating these two instructions can significantly speed up the guest as the emulation avoids the expensive single-stepping and the associated VM-exit & VM-entry.

Effectively, this eliminates two context switches in common situations, e.g., monitoring a `task_struct` in memory. Initial benchmarks show a speed-up of up to 75%.

Best,
Thomas