### PR TITLE
kvm: introspection: add KVMI_CREATE_EPT_VIEW and KVMI_DESTROY_EPT_VIEW

### DIFF
--- a/arch/x86/include/asm/kvm_page_track.h
+++ b/arch/x86/include/asm/kvm_page_track.h
@@ -106,7 +106,8 @@ struct kvm_page_track_notifier_node {
 void kvm_page_track_init(struct kvm *kvm);
 void kvm_page_track_cleanup(struct kvm *kvm);
 
-void kvm_page_track_free_memslot(struct kvm_memory_slot *free,
+void kvm_page_track_free_memslot(u16 count,
+				 struct kvm_memory_slot *free,
 				 struct kvm_memory_slot *dont);
 int kvm_page_track_create_memslot(struct kvm *kvm, struct kvm_memory_slot *slot,
 				  unsigned long npages);

--- a/arch/x86/include/asm/kvmi_host.h
+++ b/arch/x86/include/asm/kvmi_host.h
@@ -8,7 +8,6 @@ struct msr_data;
 
 #define KVMI_NUM_CR 5
 #define KVMI_NUM_MSR 0x2000
-#define KVMI_MAX_ACCESS_TREES KVM_MAX_EPT_VIEWS
 
 struct kvmi_monitor_interception {
 	bool kvmi_intercepted;

--- a/arch/x86/kvm/spp.c
+++ b/arch/x86/kvm/spp.c
@@ -111,7 +111,7 @@ struct kvm_mmu_page *kvm_spp_get_page(struct kvm_vcpu *vcpu,
 	role.direct = true;
 	role.spp = true;
 
-	for_each_valid_sp(vcpu->kvm, sp, gfn, 0) {
+	for_each_valid_sp(vcpu, sp, gfn, 0) {
 		if (sp->gfn != gfn)
 			continue;
 		if (sp->role.word != role.word)
@@ -124,7 +124,7 @@ struct kvm_mmu_page *kvm_spp_get_page(struct kvm_vcpu *vcpu,
 	sp->gfn = gfn;
 	sp->role = role;
 	hlist_add_head(&sp->hash_link,
-		       &vcpu->kvm->arch.mmu_page_hash
+		       &vcpu->arch.mmu->page_hash
 		       [0][kvm_page_table_hashfn(gfn)]);
 	kvm_x86_ops->clear_page(sp->spt);
 out:

--- a/include/linux/kvmi_host.h
+++ b/include/linux/kvmi_host.h
@@ -92,7 +92,7 @@ struct kvm_introspection {
 
 	atomic_t ev_seq;
 
-	struct radix_tree_root access_tree[KVMI_MAX_ACCESS_TREES];
+	struct radix_tree_root *access_tree;
 	rwlock_t access_tree_lock;
 
 	struct {

--- a/include/uapi/linux/kvmi.h
+++ b/include/uapi/linux/kvmi.h
@@ -30,6 +30,9 @@ enum {
 	KVMI_VCPU_ALLOC_GFN      = 41,
 	KVMI_VCPU_FREE_GFN       = 42,
 
+	KVMI_VM_CREATE_EPT_VIEW  = 43,
+	KVMI_VM_DESTROY_EPT_VIEW = 44,
+
 	KVMI_VCPU_GET_INFO         = 6,
 	KVMI_VCPU_PAUSE            = 7,
 	KVMI_VCPU_CONTROL_EVENTS   = 9,
@@ -165,6 +168,16 @@ struct kvmi_vm_query_physical {
 struct kvmi_vm_query_physical_reply {
 	__u64 gfn;
 	__u64 size;
+};
+
+struct kvmi_create_ept_view_reply {
+	__u16 view;
+	__u16 pad[3];
+};
+
+struct kvmi_destroy_ept_view {
+	__u16 view;
+	__u16 pad[3];
 };
 
 struct kvmi_vcpu_hdr {

--- a/virt/kvm/introspection/kvmi_int.h
+++ b/virt/kvm/introspection/kvmi_int.h
@@ -58,6 +58,8 @@
 			| BIT(KVMI_VM_SET_PAGE_SVE) \
 			| BIT(KVMI_VM_WRITE_PHYSICAL) \
 			| BIT(KVMI_VM_QUERY_PHYSICAL) \
+			| BIT(KVMI_VM_CREATE_EPT_VIEW) \
+			| BIT(KVMI_VM_DESTROY_EPT_VIEW) \
 			| BIT(KVMI_VCPU_ALLOC_GFN) \
 			| BIT(KVMI_VCPU_FREE_GFN) \
 			| BIT(KVMI_VCPU_GET_INFO) \
@@ -123,9 +125,9 @@ static inline bool is_event_enabled(struct kvm_vcpu *vcpu, int event)
 	return test_bit(event, VCPUI(vcpu)->ev_mask);
 }
 
-static inline bool is_valid_view(unsigned short view)
+static inline bool is_valid_view(struct kvm *kvm, unsigned short view)
 {
-	return (view < KVM_MAX_EPT_VIEWS);
+	return (view < kvm->arch.mmu_root_hpa_altviews_count);
 }
 
 static inline bool kvmi_spp_enabled(struct kvm_introspection *kvmi)
@@ -240,6 +242,8 @@ bool kvmi_arch_stop_singlestep(struct kvm_vcpu *vcpu);
 gpa_t kvmi_arch_cmd_translate_gva(struct kvm_vcpu *vcpu, gva_t gva);
 bool kvmi_arch_invalid_insn(struct kvm_vcpu *vcpu, int *emulation_type);
 u8 kvmi_arch_relax_page_access(u8 old, u8 new);
+int kvmi_arch_cmd_create_ept_view(struct kvm *kvm);
+int kvmi_arch_cmd_destroy_ept_view(struct kvm *kvm, u16 view);
 u16 kvmi_arch_cmd_get_ept_view(struct kvm_vcpu *vcpu);
 int kvmi_arch_cmd_set_ept_view(struct kvm_vcpu *vcpu, u16 view);
 int kvmi_arch_cmd_control_ept_view(struct kvm_vcpu *vcpu, u16 view,


### PR DESCRIPTION
Implementation of dynamic allocation of EPT altviews through `KVMI_CREATE_EPT_VIEW`/`KVMI_DESTROY_EPT_VIEW`.