### PR TITLE
kvm: introspection: prevent zapping of changed gfn mappings

### DIFF
--- a/arch/x86/kvm/mmu.c
+++ b/arch/x86/kvm/mmu.c
@@ -6993,7 +6993,8 @@ static void kvm_recover_nx_lpages(struct kvm *kvm)
 
 	ratio = READ_ONCE(nx_huge_pages_recovery_ratio);
 	to_zap = ratio ? DIV_ROUND_UP(kvm->stat.nx_lpage_splits, ratio) : 0;
-	while (to_zap && !list_empty(&kvm->arch.lpage_disallowed_mmu_pages)) {
+	while (to_zap && !list_empty(&kvm->arch.lpage_disallowed_mmu_pages)
+	       && !kvm->kvmi) {
 		/*
 		 * We use a separate list instead of just using active_mmu_pages
 		 * because the number of lpage_disallowed pages is expected to


### PR DESCRIPTION
KVM breaks down large pages (2 MiB) into regular pages (4 KiB) upon execution to address CVE-2018-12207 [1].
To avoid fragmenting the address space, KVM tries to restore the original large page mapping after some time has passed [2].

However, when we use `KVMI_VCPU_CHANGE_GFN` to remap a page, we disallow large page allocations in `__direct_map`. The problem is that this breaks down the page in much the same way as in the mitigation. Hence, KVM zaps our remapped page and, upon the subsequent fault, restores the original mapping in `tdp_page_fault()`.

We propose simply disabling the recovery worker when an introspection tool is connected. The resulting fragmentation turned out to be negligible in our experiments.

[1] https://lore.kernel.org/all/1573593697-25061-5-git-send-email-pbonzini@redhat.com/
[2] https://lore.kernel.org/all/1573593697-25061-7-git-send-email-pbonzini@redhat.com/