### PR TITLE
kvm: introspection: ignore permissions during address translation

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -408,7 +408,8 @@ struct kvm_mmu {
 	void (*inject_page_fault)(struct kvm_vcpu *vcpu,
 				  struct x86_exception *fault);
 	gpa_t (*gva_to_gpa)(struct kvm_vcpu *vcpu, gpa_t gva_or_gpa,
-			    u32 access, struct x86_exception *exception);
+			    u32 access, bool ignore_pfec,
+			    struct x86_exception *exception);
 	gpa_t (*translate_gpa)(struct kvm_vcpu *vcpu, gpa_t gpa, u32 access,
 			       struct x86_exception *exception);
 	int (*sync_page)(struct kvm_vcpu *vcpu,
@@ -1514,6 +1515,8 @@ gpa_t kvm_mmu_gva_to_gpa_write(struct kvm_vcpu *vcpu, gva_t gva,
 			       struct x86_exception *exception);
 gpa_t kvm_mmu_gva_to_gpa_system(struct kvm_vcpu *vcpu, gva_t gva,
 				u32 access, struct x86_exception *exception);
+gpa_t kvm_mmu_gva_to_gpa_ignore_permissions(struct kvm_vcpu *vcpu, gva_t gva,
+					   struct x86_exception *exception);
 
 void kvm_vcpu_deactivate_apicv(struct kvm_vcpu *vcpu);
 

--- a/arch/x86/kvm/kvmi.c
+++ b/arch/x86/kvm/kvmi.c
@@ -602,7 +602,7 @@ void kvmi_arch_breakpoint_event(struct kvm_vcpu *vcpu, u64 gva, u8 insn_len)
 	u32 action;
 	u64 gpa;
 
-	gpa = kvm_mmu_gva_to_gpa_system(vcpu, gva, 0, NULL);
+	gpa = kvm_mmu_gva_to_gpa_ignore_permissions(vcpu, gva, NULL);
 	old_rip = kvm_rip_read(vcpu);
 
 	trace_kvmi_event_bp_send(vcpu->vcpu_id, gpa, old_rip);
@@ -1449,7 +1449,7 @@ bool kvmi_arch_stop_singlestep(struct kvm_vcpu *vcpu)
 
 gpa_t kvmi_arch_cmd_translate_gva(struct kvm_vcpu *vcpu, gva_t gva)
 {
-	return kvm_mmu_gva_to_gpa_system(vcpu, gva, 0, NULL);
+	return kvm_mmu_gva_to_gpa_ignore_permissions(vcpu, gva, NULL);
 }
 
 bool kvmi_update_ad_flags(struct kvm_vcpu *vcpu)

--- a/arch/x86/kvm/mmu.c
+++ b/arch/x86/kvm/mmu.c
@@ -4503,7 +4503,8 @@ void kvm_mmu_sync_roots(struct kvm_vcpu *vcpu)
 EXPORT_SYMBOL_GPL(kvm_mmu_sync_roots);
 
 static gpa_t nonpaging_gva_to_gpa(struct kvm_vcpu *vcpu, gpa_t vaddr,
-				  u32 access, struct x86_exception *exception)
+				  u32 access, bool ignore_pfec,
+				  struct x86_exception *exception)
 {
 	if (exception)
 		exception->error_code = 0;
@@ -4511,7 +4512,7 @@ static gpa_t nonpaging_gva_to_gpa(struct kvm_vcpu *vcpu, gpa_t vaddr,
 }
 
 static gpa_t nonpaging_gva_to_gpa_nested(struct kvm_vcpu *vcpu, gpa_t vaddr,
-					 u32 access,
+					 u32 access,  bool ignore_pfec,
 					 struct x86_exception *exception)
 {
 	if (exception)


### PR DESCRIPTION
If `PFEC` bits are present, address translations for userspace addresses will fail. It doesn't make sense to honor permission bits during introspection of a guest. This patch will ignore those permissions for the introspection API.