### PR TITLE
kvm: introspection: remap gfns by view

### DIFF
--- a/arch/x86/include/uapi/asm/kvmi.h
+++ b/arch/x86/include/uapi/asm/kvmi.h
@@ -192,6 +192,9 @@ struct kvmi_vcpu_set_ve_info {
 };
 
 struct kvmi_vcpu_change_gfn {
+	__u16 view;
+	__u16 padding1;
+	__u32 padding2;
 	__u64 old_gfn;
 	__u64 new_gfn;
 };

--- a/arch/x86/kvm/mmu.h
+++ b/arch/x86/kvm/mmu.h
@@ -225,6 +225,6 @@ int kvm_mmu_post_init_vm(struct kvm *kvm);
 void kvm_mmu_pre_destroy_vm(struct kvm *kvm);
 bool kvm_mmu_set_ept_page_sve(struct kvm *kvm, struct kvm_memory_slot *slot,
 			      gfn_t gfn, u16 index, bool suppress);
-int kvm_mmu_change_gfn(struct kvm_vcpu *vcpu, u64 old_gfn, u64 new_gfn);
+int kvm_mmu_change_gfn_for_view(struct kvm_vcpu *vcpu, u16 view, u64 old_gfn, u64 new_gfn);
 
 #endif

--- a/include/linux/kvmi_host.h
+++ b/include/linux/kvmi_host.h
@@ -90,6 +90,8 @@ struct kvm_introspection {
 
 	DECLARE_BITMAP(vm_event_enable_mask, KVMI_NUM_EVENTS);
 
+	DECLARE_BITMAP(mmu_reload_mask, KVM_MAX_VCPUS);
+
 	atomic_t ev_seq;
 
 	struct radix_tree_root *access_tree;

--- a/virt/kvm/introspection/kvmi.c
+++ b/virt/kvm/introspection/kvmi.c
@@ -293,7 +293,7 @@ static void kvmi_clear_altviews(struct kvm *kvm)
 	for (view = 1;
 	     view < kvm->arch.mmu_root_hpa_altviews_count;
 	     view++)
-		kvmi_arch_cmd_destroy_ept_view(kvm, view);
+		kvmi_arch_destroy_ept_view(kvm, view, false);
 
 	if (refcount_dec_and_test(&kvm->arch.kvmi_refcount)) {
 		unsigned long zap_mask = ~(1 << default_view);

--- a/virt/kvm/introspection/kvmi_int.h
+++ b/virt/kvm/introspection/kvmi_int.h
@@ -243,6 +243,7 @@ gpa_t kvmi_arch_cmd_translate_gva(struct kvm_vcpu *vcpu, gva_t gva);
 bool kvmi_arch_invalid_insn(struct kvm_vcpu *vcpu, int *emulation_type);
 u8 kvmi_arch_relax_page_access(u8 old, u8 new);
 int kvmi_arch_cmd_create_ept_view(struct kvm *kvm);
+int kvmi_arch_destroy_ept_view(struct kvm *kvm, u16 view, bool sync);
 int kvmi_arch_cmd_destroy_ept_view(struct kvm *kvm, u16 view);
 u16 kvmi_arch_cmd_get_ept_view(struct kvm_vcpu *vcpu);
 int kvmi_arch_cmd_set_ept_view(struct kvm_vcpu *vcpu, u16 view);
@@ -250,7 +251,7 @@ int kvmi_arch_cmd_control_ept_view(struct kvm_vcpu *vcpu, u16 view,
 				   bool visible);
 int kvmi_arch_cmd_set_ve_info(struct kvm_vcpu *vcpu, u64 gpa,
 			      bool trigger_vmexit);
-int kvmi_arch_cmd_change_gfn(struct kvm_vcpu *vcpu, u64 old_gfn, u64 new_gfn);
+int kvmi_arch_cmd_change_gfn(struct kvm_vcpu *vcpu, u16 view, u64 old_gfn, u64 new_gfn);
 int kvmi_arch_cmd_disable_ve(struct kvm_vcpu *vcpu);
 int kvmi_arch_cmd_control_spp(struct kvm *kvm);
 int kvmi_arch_cmd_set_page_write_bitmap(struct kvm_introspection *kvmi,

--- a/virt/kvm/introspection/kvmi_msg.c
+++ b/virt/kvm/introspection/kvmi_msg.c
@@ -976,7 +976,7 @@ static int handle_vcpu_change_gfn(const struct kvmi_vcpu_cmd_job *job,
 	const struct kvmi_vcpu_change_gfn *req = _req;
 	int ec;
 
-	ec = kvmi_arch_cmd_change_gfn(job->vcpu, req->old_gfn, req->new_gfn);
+	ec = kvmi_arch_cmd_change_gfn(job->vcpu, req->view, req->old_gfn, req->new_gfn);
 
 	return kvmi_msg_vcpu_reply(job, msg, ec, NULL, 0);
 }


### PR DESCRIPTION
This PR adds functionality to remap GFNs on inactive views, thereby avoiding superfluous context switches with the introspection application.

Furthermore, we simplified the remapping implementation by eliminating redundant branches and hooked it up directly to `__direct_map`.

Best,
Thomas