### PR TITLE
Fix unsigned index underflow in grow_ept_tracks()

### DIFF
--- a/arch/x86/kvm/kvmi.c
+++ b/arch/x86/kvm/kvmi.c
@@ -734,7 +734,7 @@ static bool grow_ept_tracks(struct kvm *kvm,
 {
 	struct kvm_memory_slot *slot;
 	u16 old = kvm->arch.mmu_root_hpa_altviews_count;
-	size_t i;
+	int i;
 
 	for (i = 0; i < KVM_ADDRESS_SPACE_NUM; i++)
 		kvm_for_each_memslot(slot, __kvm_memslots(kvm, i))


### PR DESCRIPTION
grow_ept_tracks() uses a rollback loop that iterates backward over KVM_ADDRESS_SPACE_NUM. However, the loop index i was declared as size_t, which is an unsigned type. In the failure path, the rollback loop uses the condition i >= 0, which is always true for unsigned types and can result in underflow and an infinite loop.

Fix this by changing the index type to a signed integer so that the rollback condition works as intended.

This change fixes a potential infinite loop and makes the error handling logic safe.

No functional behavior is changed in the success path.